### PR TITLE
feat(solidity): optimize struct slot computation across Mangrove

### DIFF
--- a/packages/mangrove-solidity/src/MgvHasOffers.sol
+++ b/packages/mangrove-solidity/src/MgvHasOffers.sol
@@ -144,14 +144,6 @@ contract MgvHasOffers is MgvRoot {
     }
   }
 
-  // function semibook(address outbound_tkn, address inbound_tkn) internal view returns (mapping(uint => MgvStructs.OfferPacked) storage sb) {
-  //   sb = offers[outbound_tkn][inbound_tkn];
-  // }
-
-  // function semibookDetail(address outbound_tkn, address inbound_tkn) internal view returns (mapping(uint => MgvStructs.OfferDetailPacked) storage sbd) {
-  //   sbd = offerDetails[outbound_tkn][inbound_tkn];
-  // }
-
   function toSemibook(bytes32 val) internal pure returns (mapping(uint => MgvStructs.OfferPacked) storage sb) {
     assembly {
       sb.slot := val

--- a/packages/mangrove-solidity/src/MgvHasOffers.sol
+++ b/packages/mangrove-solidity/src/MgvHasOffers.sol
@@ -144,6 +144,26 @@ contract MgvHasOffers is MgvRoot {
     }
   }
 
+  /* ## Pointers to partially evaluated mappings
+    Reminder: deep mappings are accessed by composing the hash of each successive key. For the mapping at `map` at slot `slot`, `map[key1][key2]` points to keccak256(bytes.concat(key2, keccak256(bytes.concat(key1, uint(slot))))).
+
+    To save gas, we save the partial evaluation of offerDetail and offer when it makes sense. Since memory structs cannot contain storage mappings, we convert to/from bytes32.
+  */
+
+  /* Return the storage pointer given by a partially evaluated mapping (`Offer` or `OfferDetail`), cast to a bytes32 */
+  function tob32(mapping(uint => MgvStructs.OfferPacked) storage sb) internal pure returns (bytes32 val) {
+    assembly {
+      val := sb.slot
+    }
+  }
+
+  function tob32(mapping(uint => MgvStructs.OfferDetailPacked) storage sbd) internal pure returns (bytes32 val) {
+    assembly {
+      val := sbd.slot
+    }
+  }
+
+  /* Return given bytes32 cat to a partially evaluated mapping (`Offer` or `OfferDetail`) */
   function toSemibook(bytes32 val) internal pure returns (mapping(uint => MgvStructs.OfferPacked) storage sb) {
     assembly {
       sb.slot := val
@@ -157,18 +177,6 @@ contract MgvHasOffers is MgvRoot {
   {
     assembly {
       sbd.slot := val
-    }
-  }
-
-  function tob32(mapping(uint => MgvStructs.OfferPacked) storage sb) internal pure returns (bytes32 val) {
-    assembly {
-      val := sb.slot
-    }
-  }
-
-  function tob32(mapping(uint => MgvStructs.OfferDetailPacked) storage sbd) internal pure returns (bytes32 val) {
-    assembly {
-      val := sbd.slot
     }
   }
 }

--- a/packages/mangrove-solidity/src/MgvHasOffers.sol
+++ b/packages/mangrove-solidity/src/MgvHasOffers.sol
@@ -145,4 +145,32 @@ contract MgvHasOffers is MgvRoot {
       return offer.gives() > 0;
     }
   }
+
+  function semibook(bytes32 val) internal pure returns (mapping(uint => MgvStructs.OfferPacked) storage sb) {
+    assembly {
+      sb.slot := val
+    }
+  }
+
+  function semibookDetail(bytes32 val)
+    internal
+    pure
+    returns (mapping(uint => MgvStructs.OfferDetailPacked) storage sbd)
+  {
+    assembly {
+      sbd.slot := val
+    }
+  }
+
+  function tob32(mapping(uint => MgvStructs.OfferPacked) storage sb) internal pure returns (bytes32 val) {
+    assembly {
+      val := sb.slot
+    }
+  }
+
+  function tob32(mapping(uint => MgvStructs.OfferDetailPacked) storage sbd) internal pure returns (bytes32 val) {
+    assembly {
+      val := sbd.slot
+    }
+  }
 }

--- a/packages/mangrove-solidity/src/MgvOfferMaking.sol
+++ b/packages/mangrove-solidity/src/MgvOfferMaking.sol
@@ -22,6 +22,7 @@ pragma abicoder v2;
 
 import {IMaker, HasMgvEvents, MgvStructs} from "./MgvLib.sol";
 import {MgvHasOffers} from "./MgvHasOffers.sol";
+import "forge-std/console.sol";
 
 /* `MgvOfferMaking` contains market-making-related functions. */
 contract MgvOfferMaking is MgvHasOffers {
@@ -92,6 +93,8 @@ contract MgvOfferMaking is MgvHasOffers {
 
       ofp.outbound_tkn = outbound_tkn;
       ofp.inbound_tkn = inbound_tkn;
+      ofp.semibook = tob32(offers[outbound_tkn][inbound_tkn]);
+      ofp.semibookDetails = tob32(offerDetails[outbound_tkn][inbound_tkn]);
       ofp.wants = wants;
       ofp.gives = gives;
       ofp.gasreq = gasreq;
@@ -134,9 +137,6 @@ contract MgvOfferMaking is MgvHasOffers {
     unchecked {
       OfferPack memory ofp;
       (ofp.global, ofp.local) = config(outbound_tkn, inbound_tkn);
-      mapping(uint => MgvStructs.OfferPacked) storage semibook = offers[outbound_tkn][inbound_tkn];
-      ofp.semibook = tob32(semibook);
-      ofp.semibookDetails = tob32(offerDetails[outbound_tkn][inbound_tkn]);
       unlockedMarketOnly(ofp.local);
       activeMarketOnly(ofp.global, ofp.local);
       if (msg.value > 0) {
@@ -144,6 +144,9 @@ contract MgvOfferMaking is MgvHasOffers {
       }
       ofp.outbound_tkn = outbound_tkn;
       ofp.inbound_tkn = inbound_tkn;
+      mapping(uint => MgvStructs.OfferPacked) storage semibook = offers[outbound_tkn][inbound_tkn];
+      ofp.semibook = tob32(semibook);
+      ofp.semibookDetails = tob32(offerDetails[outbound_tkn][inbound_tkn]);
       ofp.wants = wants;
       ofp.gives = gives;
       ofp.id = offerId;
@@ -339,6 +342,11 @@ contract MgvOfferMaking is MgvHasOffers {
       MgvStructs.OfferPacked ofr =
         MgvStructs.Offer.pack({__prev: prev, __next: next, __wants: ofp.wants, __gives: ofp.gives});
       toSemibook(ofp.semibook)[ofp.id] = ofr;
+      // console.log("local",MgvStructs.OfferPacked.unwrap(ofr));
+      // console.log("found",MgvStructs.OfferPacked.unwrap(offers[ofp.outbound_tkn][ofp.inbound_tkn][ofp.id]));
+      // console.log("found semibook",MgvStructs.OfferPacked.unwrap(toSemibook(ofp.semibook)[ofp.id]));
+      // console.log("semibook",uint(ofp.semibook));
+      // console.log("offer",uint(tob32(offers[ofp.outbound_tkn][ofp.inbound_tkn])));
     }
   }
 

--- a/packages/mangrove-solidity/src/MgvOfferMaking.sol
+++ b/packages/mangrove-solidity/src/MgvOfferMaking.sol
@@ -283,7 +283,7 @@ contract MgvOfferMaking is MgvHasOffers {
       /* We now write the new `offerDetails` and remember the previous provision (0 by default, for new offers) to balance out maker's `balanceOf`. */
       uint oldProvision;
       {
-        MgvStructs.OfferDetailPacked offerDetail = offerDetails[ofp.outbound_tkn][ofp.inbound_tkn][ofp.id];
+        MgvStructs.OfferDetailPacked offerDetail = toSemibookDetails(ofp.semibookDetails)[ofp.id];
         if (update) {
           require(msg.sender == offerDetail.maker(), "mgv/updateOffer/unauthorized");
           oldProvision = 10 ** 9 * offerDetail.gasprice() * (offerDetail.gasreq() + offerDetail.offer_gasbase());
@@ -295,7 +295,7 @@ contract MgvOfferMaking is MgvHasOffers {
             || offerDetail.offer_gasbase() != ofp.local.offer_gasbase()
         ) {
           uint offer_gasbase = ofp.local.offer_gasbase();
-          offerDetails[ofp.outbound_tkn][ofp.inbound_tkn][ofp.id] = MgvStructs.OfferDetail.pack({
+          toSemibookDetails(ofp.semibookDetails)[ofp.id] = MgvStructs.OfferDetail.pack({
             __maker: msg.sender,
             __gasreq: ofp.gasreq,
             __offer_gasbase: offer_gasbase,
@@ -417,7 +417,7 @@ contract MgvOfferMaking is MgvHasOffers {
       uint weight1 = wants1 * gives2;
       uint weight2 = wants2 * gives1;
       if (weight1 == weight2) {
-        uint gasreq1 = offerDetails[ofp.outbound_tkn][ofp.inbound_tkn][offerId1].gasreq();
+        uint gasreq1 = toSemibookDetails(ofp.semibookDetails)[offerId1].gasreq();
         uint gasreq2 = ofp.gasreq;
         return (gives1 * gasreq2 >= gives2 * gasreq1);
       } else {

--- a/packages/mangrove-solidity/src/MgvOfferMaking.sol
+++ b/packages/mangrove-solidity/src/MgvOfferMaking.sol
@@ -22,7 +22,6 @@ pragma abicoder v2;
 
 import {IMaker, HasMgvEvents, MgvStructs} from "./MgvLib.sol";
 import {MgvHasOffers} from "./MgvHasOffers.sol";
-import "forge-std/console.sol";
 
 /* `MgvOfferMaking` contains market-making-related functions. */
 contract MgvOfferMaking is MgvHasOffers {
@@ -342,11 +341,6 @@ contract MgvOfferMaking is MgvHasOffers {
       MgvStructs.OfferPacked ofr =
         MgvStructs.Offer.pack({__prev: prev, __next: next, __wants: ofp.wants, __gives: ofp.gives});
       toSemibook(ofp.semibook)[ofp.id] = ofr;
-      // console.log("local",MgvStructs.OfferPacked.unwrap(ofr));
-      // console.log("found",MgvStructs.OfferPacked.unwrap(offers[ofp.outbound_tkn][ofp.inbound_tkn][ofp.id]));
-      // console.log("found semibook",MgvStructs.OfferPacked.unwrap(toSemibook(ofp.semibook)[ofp.id]));
-      // console.log("semibook",uint(ofp.semibook));
-      // console.log("offer",uint(tob32(offers[ofp.outbound_tkn][ofp.inbound_tkn])));
     }
   }
 

--- a/packages/mangrove-solidity/src/MgvOfferMaking.sol
+++ b/packages/mangrove-solidity/src/MgvOfferMaking.sol
@@ -46,6 +46,8 @@ contract MgvOfferMaking is MgvHasOffers {
     MgvStructs.LocalPacked local;
     // used on update only
     MgvStructs.OfferPacked oldOffer;
+    bytes32 semibook;
+    bytes32 semibookDetails;
   }
 
   /* The function `newOffer` is for market makers only; no match with the existing book is done. A maker specifies how much `inbound_tkn` it `wants` and how much `outbound_tkn` it `gives`.
@@ -132,6 +134,9 @@ contract MgvOfferMaking is MgvHasOffers {
     unchecked {
       OfferPack memory ofp;
       (ofp.global, ofp.local) = config(outbound_tkn, inbound_tkn);
+      mapping(uint => MgvStructs.OfferPacked) storage semibook = offers[outbound_tkn][inbound_tkn];
+      ofp.semibook = tob32(semibook);
+      ofp.semibookDetails = tob32(offerDetails[outbound_tkn][inbound_tkn]);
       unlockedMarketOnly(ofp.local);
       activeMarketOnly(ofp.global, ofp.local);
       if (msg.value > 0) {
@@ -145,7 +150,7 @@ contract MgvOfferMaking is MgvHasOffers {
       ofp.gasreq = gasreq;
       ofp.gasprice = gasprice;
       ofp.pivotId = pivotId;
-      ofp.oldOffer = offers[outbound_tkn][inbound_tkn][offerId];
+      ofp.oldOffer = semibook[offerId];
       // Save local config
       MgvStructs.LocalPacked oldLocal = ofp.local;
       /* The second argument indicates that we are updating an existing offer, not creating a new one. */
@@ -167,21 +172,23 @@ contract MgvOfferMaking is MgvHasOffers {
     unchecked {
       (, MgvStructs.LocalPacked local) = config(outbound_tkn, inbound_tkn);
       unlockedMarketOnly(local);
-      MgvStructs.OfferPacked offer = offers[outbound_tkn][inbound_tkn][offerId];
-      MgvStructs.OfferDetailPacked offerDetail = offerDetails[outbound_tkn][inbound_tkn][offerId];
+      mapping(uint => MgvStructs.OfferPacked) storage semibook = offers[outbound_tkn][inbound_tkn];
+      mapping(uint => MgvStructs.OfferDetailPacked) storage semibookDetails = offerDetails[outbound_tkn][inbound_tkn];
+      MgvStructs.OfferPacked offer = semibook[offerId];
+      MgvStructs.OfferDetailPacked offerDetail = semibookDetails[offerId];
       require(msg.sender == offerDetail.maker(), "mgv/retractOffer/unauthorized");
 
       /* Here, we are about to un-live an offer, so we start by taking it out of the book by stitching together its previous and next offers. Note that unconditionally calling `stitchOffers` would break the book since it would connect offers that may have since moved. */
       if (isLive(offer)) {
         MgvStructs.LocalPacked oldLocal = local;
-        local = stitchOffers(outbound_tkn, inbound_tkn, offer.prev(), offer.next(), local);
+        local = stitchOffers(semibook, offer.prev(), offer.next(), local);
         /* If calling `stitchOffers` has changed the current `best` offer, we update the storage. */
         if (!oldLocal.eq(local)) {
           locals[outbound_tkn][inbound_tkn] = local;
         }
       }
       /* Set `gives` to 0. Moreover, the last argument depends on whether the user wishes to get their provision back (if true, `gasprice` will be set to 0 as well). */
-      dirtyDeleteOffer(outbound_tkn, inbound_tkn, offerId, offer, offerDetail, deprovision);
+      dirtyDeleteOffer(semibook, semibookDetails, offerId, offer, offerDetail, deprovision);
 
       /* If the user wants to get their provision back, we compute its provision from the offer's `gasprice`, `offer_gasbase` and `gasreq`. */
       if (deprovision) {
@@ -312,27 +319,26 @@ contract MgvOfferMaking is MgvHasOffers {
       if (!isLive(ofp.oldOffer) || prev != ofp.oldOffer.prev()) {
         /* * If the offer is not the best one, we update its predecessor; otherwise we update the `best` value. */
         if (prev != 0) {
-          offers[ofp.outbound_tkn][ofp.inbound_tkn][prev] = offers[ofp.outbound_tkn][ofp.inbound_tkn][prev].next(ofp.id);
+          toSemibook(ofp.semibook)[prev] = toSemibook(ofp.semibook)[prev].next(ofp.id);
         } else {
           ofp.local = ofp.local.best(ofp.id);
         }
 
         /* * If the offer is not the last one, we update its successor. */
         if (next != 0) {
-          offers[ofp.outbound_tkn][ofp.inbound_tkn][next] = offers[ofp.outbound_tkn][ofp.inbound_tkn][next].prev(ofp.id);
+          toSemibook(ofp.semibook)[next] = toSemibook(ofp.semibook)[next].prev(ofp.id);
         }
 
         /* * Recall that in this branch, the offer has changed location, or is not currently in the book. If the offer is not new and already in the book, we must remove it from its previous location by stitching its previous prev/next. */
         if (update && isLive(ofp.oldOffer)) {
-          ofp.local =
-            stitchOffers(ofp.outbound_tkn, ofp.inbound_tkn, ofp.oldOffer.prev(), ofp.oldOffer.next(), ofp.local);
+          ofp.local = stitchOffers(toSemibook(ofp.semibook), ofp.oldOffer.prev(), ofp.oldOffer.next(), ofp.local);
         }
       }
 
       /* With the `prev`/`next` in hand, we finally store the offer in the `offers` map. */
       MgvStructs.OfferPacked ofr =
         MgvStructs.Offer.pack({__prev: prev, __next: next, __wants: ofp.wants, __gives: ofp.gives});
-      offers[ofp.outbound_tkn][ofp.inbound_tkn][ofp.id] = ofr;
+      toSemibook(ofp.semibook)[ofp.id] = ofr;
     }
   }
 
@@ -346,13 +352,12 @@ contract MgvOfferMaking is MgvHasOffers {
       uint nextId;
       uint pivotId = ofp.pivotId;
       /* Get `pivot`, optimizing for the case where pivot info is already known */
-      MgvStructs.OfferPacked pivot =
-        pivotId == ofp.id ? ofp.oldOffer : offers[ofp.outbound_tkn][ofp.inbound_tkn][pivotId];
+      MgvStructs.OfferPacked pivot = pivotId == ofp.id ? ofp.oldOffer : toSemibook(ofp.semibook)[pivotId];
 
       /* In case pivotId is not an active offer, it is unusable (since it is out of the book). We default to the current best offer. If the book is empty pivot will be 0. That is handled through a test in the `better` comparison function. */
       if (!isLive(pivot)) {
         pivotId = ofp.local.best();
-        pivot = offers[ofp.outbound_tkn][ofp.inbound_tkn][pivotId];
+        pivot = toSemibook(ofp.semibook)[pivotId];
       }
 
       /* * Pivot is better than `wants/gives`, we follow `next`. */
@@ -360,7 +365,7 @@ contract MgvOfferMaking is MgvHasOffers {
         MgvStructs.OfferPacked pivotNext;
         while (pivot.next() != 0) {
           uint pivotNextId = pivot.next();
-          pivotNext = offers[ofp.outbound_tkn][ofp.inbound_tkn][pivotNextId];
+          pivotNext = toSemibook(ofp.semibook)[pivotNextId];
           if (better(ofp, pivotNext, pivotNextId)) {
             pivotId = pivotNextId;
             pivot = pivotNext;
@@ -376,7 +381,7 @@ contract MgvOfferMaking is MgvHasOffers {
         MgvStructs.OfferPacked pivotPrev;
         while (pivot.prev() != 0) {
           uint pivotPrevId = pivot.prev();
-          pivotPrev = offers[ofp.outbound_tkn][ofp.inbound_tkn][pivotPrevId];
+          pivotPrev = toSemibook(ofp.semibook)[pivotPrevId];
           if (better(ofp, pivotPrev, pivotPrevId)) {
             break;
           } else {

--- a/packages/mangrove-solidity/src/MgvOfferTaking.sol
+++ b/packages/mangrove-solidity/src/MgvOfferTaking.sol
@@ -36,7 +36,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
     bool fillWants; // used globally
     uint feePaid; // used globally
     bytes32 semibook;
-    bytes32 semibookDetail;
+    bytes32 semibookDetails;
   }
 
   /* # Market Orders */
@@ -84,7 +84,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
       mor.taker = taker;
       mor.fillWants = fillWants;
       mor.semibook = tob32(offers[outbound_tkn][inbound_tkn]);
-      mor.semibookDetail = tob32(offerDetails[outbound_tkn][inbound_tkn]);
+      mor.semibookDetails = tob32(offerDetails[outbound_tkn][inbound_tkn]);
 
       /* `SingleOrder` is defined in `MgvLib.sol` and holds information for ordering the execution of one offer. */
       MgvLib.SingleOrder memory sor;
@@ -93,7 +93,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
       (sor.global, sor.local) = config(outbound_tkn, inbound_tkn);
       /* Throughout the execution of the market order, the `sor`'s offer id and other parameters will change. We start with the current best offer id (0 if the book is empty). */
       sor.offerId = sor.local.best();
-      sor.offer = semibook(mor.semibook)[sor.offerId];
+      sor.offer = toSemibook(mor.semibook)[sor.offerId];
       /* `sor.wants` and `sor.gives` may evolve, but they are initially however much remains in the market order. */
       sor.wants = takerWants;
       sor.gives = takerGives;
@@ -153,7 +153,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
         bytes32 mgvData;
 
         /* Load additional information about the offer. We don't do it earlier to save one storage read in case `proceed` was false. */
-        sor.offerDetail = semibookDetail(mor.semibookDetail)[sor.offerId];
+        sor.offerDetail = toSemibookDetails(mor.semibookDetails)[sor.offerId];
 
         /* `execute` will adjust `sor.wants`,`sor.gives`, and may attempt to execute the offer if its price is low enough. It is crucial that an error due to `taker` triggers a revert. That way, [`mgvData`](#MgvOfferTaking/statusCodes) not in `["mgv/notExecuted","mgv/tradeSuccess"]` means the failure is the maker's fault. */
         /* Post-execution, `sor.wants`/`sor.gives` reflect how much was sent/taken by the offer. We will need it after the recursive call, so we save it in local variables. Same goes for `offerId`, `sor.offer` and `sor.offerDetail`. */
@@ -177,7 +177,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
         */
           sor.gives = mor.initialGives - mor.totalGave;
           sor.offerId = sor.offer.next();
-          sor.offer = semibook(mor.semibook)[sor.offerId];
+          sor.offer = toSemibook(mor.semibook)[sor.offerId];
         }
 
         /* note that internalMarketOrder may be called twice with same offerId, but in that case `proceed` will be false! */
@@ -204,7 +204,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
         /* If `proceed` is false, the taker has gotten its requested volume, or we have reached the end of the book, we conclude the market order. */
       } else {
         /* During the market order, all executed offers have been removed from the book. We end by stitching together the `best` offer pointer and the new best offer. */
-        sor.local = stitchOffers(sor.outbound_tkn, sor.inbound_tkn, 0, sor.offerId, sor.local);
+        sor.local = stitchOffers(toSemibook(mor.semibook), 0, sor.offerId, sor.local);
         /* <a id="internalMarketOrder/liftReentrancy"></a>Now that the market order is over, we can lift the lock on the book. In the same operation we
 
       * lift the reentrancy lock, and
@@ -261,7 +261,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
       mor.taker = taker;
       mor.fillWants = fillWants;
       mor.semibook = tob32(offers[outbound_tkn][inbound_tkn]);
-      mor.semibookDetail = tob32(offerDetails[outbound_tkn][inbound_tkn]);
+      mor.semibookDetails = tob32(offerDetails[outbound_tkn][inbound_tkn]);
 
       /* For the snipes to even start, the market needs to be both active and not currently protected from reentrancy. */
       activeMarketOnly(sor.global, sor.local);
@@ -300,8 +300,8 @@ abstract contract MgvOfferTaking is MgvHasOffers {
 
         /* Initialize single order struct. */
         sor.offerId = targets[i][0];
-        sor.offer = semibook(mor.semibook)[sor.offerId];
-        sor.offerDetail = semibookDetail(mor.semibookDetail)[sor.offerId];
+        sor.offer = toSemibook(mor.semibook)[sor.offerId];
+        sor.offerDetail = toSemibookDetails(mor.semibookDetails)[sor.offerId];
 
         /* If we removed the `isLive` conditional, a single expired or nonexistent offer in `targets` would revert the entire transaction (by the division by `offer.gives` below since `offer.gives` would be 0). We also check that `gasreq` is not worse than specified. A taker who does not care about `gasreq` can specify any amount larger than $2^{24}-1$. A mismatched price will be detected by `execute`. */
         if (!isLive(sor.offer) || sor.offerDetail.gasreq() > targets[i][3]) {
@@ -327,7 +327,7 @@ abstract contract MgvOfferTaking is MgvHasOffers {
 
           /* In the market order, we were able to avoid stitching back offers after every `execute` since we knew a continuous segment starting at best would be consumed. Here, we cannot do this optimisation since offers in the `targets` array may be anywhere in the book. So we stitch together offers immediately after each `execute`. */
           if (mgvData != "mgv/notExecuted") {
-            sor.local = stitchOffers(sor.outbound_tkn, sor.inbound_tkn, sor.offer.prev(), sor.offer.next(), sor.local);
+            sor.local = stitchOffers(toSemibook(mor.semibook), sor.offer.prev(), sor.offer.next(), sor.local);
           }
 
           /* <a id="internalSnipes/liftReentrancy"></a> Now that the current snipe is over, we can lift the lock on the book. In the same operation we
@@ -492,7 +492,12 @@ abstract contract MgvOfferTaking is MgvHasOffers {
 
       /* Delete the offer. The last argument indicates whether the offer should be stripped of its provision (yes if execution failed, no otherwise). We cannot partially strip an offer provision (for instance, remove only the penalty from a failing offer and leave the rest) since the provision associated with an offer is always deduced from the (gasprice,gasbase,gasreq) parameters and not stored independently. We delete offers whether the amount remaining on offer is > density or not for the sake of uniformity (code is much simpler). We also expect prices to move often enough that the maker will want to update their price anyway. To simulate leaving the remaining volume in the offer, the maker can program their `makerPosthook` to `updateOffer` and put the remaining volume back in. */
       dirtyDeleteOffer(
-        sor.outbound_tkn, sor.inbound_tkn, sor.offerId, sor.offer, sor.offerDetail, mgvData != "mgv/tradeSuccess"
+        toSemibook(mor.semibook),
+        toSemibookDetails(mor.semibookDetails),
+        sor.offerId,
+        sor.offer,
+        sor.offerDetail,
+        mgvData != "mgv/tradeSuccess"
       );
     }
   }


### PR DESCRIPTION
This PR reinstates & extends @lnist 's partially evaluated storage pointer optimizations.

Questions:
1. Is it correct?
2. Is it worth it?

The gas usage and differences wrt master are (for tests in `Gas.t.sol`):
* test_market_order_1
  * Gas used: 155558 **(-443)**
* test_market_order_8
  * Gas used: 477017 **(-5391)**
* test_new_offer
  * Gas used: 81628 **(-690)**
* test_partial_take_offer
  * Gas used: 155424 **(-11)**
* test_take_offer
  * Gas used: 155413 **(-11)**
* test_update_full_offer
  * Gas used: 36725 **(-229)**
* test_update_min_move_0_offer
  * Gas used: 24423 **(-205)**
* test_update_min_move_3_offer
  * Gas used: 21399 **(-1206)**
* test_update_min_move_6_offer
  * Gas used: 22953 **(-1701)**

┆Issue is synchronized with this [Monday item](https://mangrovedao.monday.com/boards/3894180513/pulses/3901913077) by [Unito](https://www.unito.io)
