### PR TITLE
refactor!(bots): Replace ETHEREUM_NODE_URL with RPC_NODE_URL in all bots

### DIFF
--- a/packages/bot-cleaning/.env.local.example
+++ b/packages/bot-cleaning/.env.local.example
@@ -3,7 +3,7 @@
 ############################
 
 # The URL for an Ethereum-compatible JSON-RPC endpoint
-ETHEREUM_NODE_URL=https://eth-mainnet.alchemyapi.io/v2/<API key>
+RPC_NODE_URL=https://eth-mainnet.alchemyapi.io/v2/<API key>
 
 
 ############################

--- a/packages/bot-cleaning/README.md
+++ b/packages/bot-cleaning/README.md
@@ -27,9 +27,9 @@ The JSON-RPC endpoint and private key that the bot should use must be specified 
 
 ```yaml
 # The URL for an Ethereum-compatible JSON-RPC endpoint
-ETHEREUM_NODE_URL=<URL>
+RPC_NODE_URL=<URL>
 # example:
-ETHEREUM_NODE_URL=https://eth-mainnet.alchemyapi.io/v2/abcd-12345679
+RPC_NODE_URL=https://eth-mainnet.alchemyapi.io/v2/abcd-12345679
 
 # The private key for transaction signing
 PRIVATE_KEY=<private key>

--- a/packages/bot-failing-offer/.env.local.example
+++ b/packages/bot-failing-offer/.env.local.example
@@ -2,8 +2,8 @@
 # Ethereum network secrets #
 ############################
 
-# The URL for an Ethereum endpoint
-ETHEREUM_NODE_URL=https://eth-mainnet.alchemyapi.io/v2/<API key>
+# The URL for an Ethereum-compatible JSON-RPC endpoint
+RPC_NODE_URL=https://eth-mainnet.alchemyapi.io/v2/<API key>
 
 
 ############################

--- a/packages/bot-failing-offer/README.md
+++ b/packages/bot-failing-offer/README.md
@@ -30,9 +30,9 @@ The JSON-RPC endpoint and private key that the bot should use must be specified 
 
 ```yaml
 # The URL for an Ethereum-compatible JSON-RPC endpoint
-ETHEREUM_NODE_URL=<URL>
+RPC_NODE_URL=<URL>
 # example:
-ETHEREUM_NODE_URL=https://eth-mainnet.alchemyapi.io/v2/abcd-12345679
+RPC_NODE_URL=https://eth-mainnet.alchemyapi.io/v2/abcd-12345679
 
 # The private key for transaction signing
 PRIVATE_KEY=<private key>

--- a/packages/bot-maker-noise/README.md
+++ b/packages/bot-maker-noise/README.md
@@ -30,9 +30,9 @@ The JSON-RPC endpoint and private key that the bot should use must be specified 
 
 ```yaml
 # The URL for an Ethereum-compatible JSON-RPC endpoint
-ETHEREUM_NODE_URL=<URL>
+RPC_NODE_URL=<URL>
 # example:
-ETHEREUM_NODE_URL=https://eth-mainnet.alchemyapi.io/v2/abcd-12345679
+RPC_NODE_URL=https://eth-mainnet.alchemyapi.io/v2/abcd-12345679
 
 # The private key for transaction signing
 PRIVATE_KEY=<private key>

--- a/packages/bot-taker-greedy/.env.local.example
+++ b/packages/bot-taker-greedy/.env.local.example
@@ -3,7 +3,7 @@
 ############################
 
 # The URL for an Ethereum-compatible JSON-RPC endpoint
-ETHEREUM_NODE_URL=https://eth-mainnet.alchemyapi.io/v2/<API key>
+RPC_NODE_URL=https://eth-mainnet.alchemyapi.io/v2/<API key>
 
 
 ############################

--- a/packages/bot-taker-greedy/README.md
+++ b/packages/bot-taker-greedy/README.md
@@ -27,9 +27,9 @@ The JSON-RPC endpoint and private key that the bot should use must be specified 
 
 ```yaml
 # The URL for an Ethereum-compatible JSON-RPC endpoint
-ETHEREUM_NODE_URL=<URL>
+RPC_NODE_URL=<URL>
 # example:
-ETHEREUM_NODE_URL=https://eth-mainnet.alchemyapi.io/v2/abcd-12345679
+RPC_NODE_URL=https://eth-mainnet.alchemyapi.io/v2/abcd-12345679
 
 # The private key for transaction signing
 PRIVATE_KEY=<private key>

--- a/packages/bot-template/.env.local.example
+++ b/packages/bot-template/.env.local.example
@@ -2,8 +2,8 @@
 # Ethereum network secrets #
 ############################
 
-# The URL for an Ethereum endpoint
-ETHEREUM_NODE_URL=https://eth-mainnet.alchemyapi.io/v2/<API key>
+# The URL for an Ethereum-compatible JSON-RPC endpoint
+RPC_NODE_URL=https://eth-mainnet.alchemyapi.io/v2/<API key>
 
 
 ############################

--- a/packages/bot-template/README.md
+++ b/packages/bot-template/README.md
@@ -31,9 +31,9 @@ The JSON-RPC endpoint and private key that the bot should use must be specified 
 
 ```yaml
 # The URL for an Ethereum-compatible JSON-RPC endpoint
-ETHEREUM_NODE_URL=<URL>
+RPC_NODE_URL=<URL>
 # example:
-ETHEREUM_NODE_URL=https://eth-mainnet.alchemyapi.io/v2/abcd-12345679
+RPC_NODE_URL=https://eth-mainnet.alchemyapi.io/v2/abcd-12345679
 
 # The private key for transaction signing
 PRIVATE_KEY=<private key>

--- a/packages/bot-updategas/.env.local.example
+++ b/packages/bot-updategas/.env.local.example
@@ -2,8 +2,8 @@
 # Ethereum network secrets #
 ############################
 
-# The URL for an Ethereum endpoint
-ETHEREUM_NODE_URL=https://eth-mainnet.alchemyapi.io/v2/<API key>
+# The URL for an Ethereum-compatible JSON-RPC endpoint
+RPC_NODE_URL=https://eth-mainnet.alchemyapi.io/v2/<API key>
 
 
 ############################

--- a/packages/bot-updategas/README.md
+++ b/packages/bot-updategas/README.md
@@ -22,9 +22,9 @@ The JSON-RPC endpoint and private key that the bot should use must be specified 
 
 ```yaml
 # The URL for an Ethereum-compatible JSON-RPC endpoint
-ETHEREUM_NODE_URL=<URL>
+RPC_NODE_URL=<URL>
 # example:
-ETHEREUM_NODE_URL=https://eth-mainnet.alchemyapi.io/v2/abcd-12345679
+RPC_NODE_URL=https://eth-mainnet.alchemyapi.io/v2/abcd-12345679
 
 # The private key for transaction signing
 PRIVATE_KEY=<private key>

--- a/packages/bot-utils/.env.local.example
+++ b/packages/bot-utils/.env.local.example
@@ -3,7 +3,7 @@
 ############################
 
 # The URL for an Ethereum endpoint
-ETHEREUM_NODE_URL=https://eth-mainnet.alchemyapi.io/v2/<API key>
+RPC_NODE_URL=https://eth-mainnet.alchemyapi.io/v2/<API key>
 
 
 ############################

--- a/packages/bot-utils/README.md
+++ b/packages/bot-utils/README.md
@@ -31,9 +31,9 @@ The JSON-RPC endpoint and private key that the bot should use must be specified 
 
 ```yaml
 # The URL for an Ethereum-compatible JSON-RPC endpoint
-ETHEREUM_NODE_URL=<URL>
+RPC_NODE_URL=<URL>
 # example:
-ETHEREUM_NODE_URL=https://eth-mainnet.alchemyapi.io/v2/abcd-12345679
+RPC_NODE_URL=https://eth-mainnet.alchemyapi.io/v2/abcd-12345679
 
 # The private key for transaction signing
 PRIVATE_KEY=<private key>

--- a/packages/bot-utils/src/setup.ts
+++ b/packages/bot-utils/src/setup.ts
@@ -89,15 +89,13 @@ export class Setup {
       this.stopAndExit(ExitCode.UncaughtException, server, scheduler);
     });
 
-    if (!process.env["ETHEREUM_NODE_URL"]) {
-      throw new Error(
-        "No URL for a node has been provided in ETHEREUM_NODE_URL"
-      );
+    if (!process.env["RPC_NODE_URL"]) {
+      throw new Error("No URL for a node has been provided in RPC_NODE_URL");
     }
     if (!process.env["PRIVATE_KEY"]) {
       throw new Error("No private key provided in PRIVATE_KEY");
     }
-    const provider = getDefaultProvider(process.env["ETHEREUM_NODE_URL"]);
+    const provider = getDefaultProvider(process.env["RPC_NODE_URL"]);
     const signer = new Wallet(process.env["PRIVATE_KEY"], provider);
     const nonceManager = new NonceManager(signer);
     const mgv = await Mangrove.connect({ signer: nonceManager });


### PR DESCRIPTION
The node URL does not need to point to an Ethereum node, but an Ethereum-compatible JSON-RPC node, so the old name was confusing.