### PR TITLE
feat!(market): Remove dangerous behaviour when price is null

### DIFF
--- a/packages/mangrove.js/CHANGELOG.md
+++ b/packages/mangrove.js/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fix `Semibook.simulateMarketOrder`. Fixes `Semibook.estimateVolume`, `Market.(estimateVolume[|ToReceive|ToSpend])`.
 - EOA offers (on the fly) do not require any gasreq
+- Remove unsafe option to set `price=null` in `market.{buy|sell}` as simulating true market orders is prone to sandwich attacks and therefore not encouraged.
 
 # 0.11.4 (October 2022)
 

--- a/packages/mangrove.js/src/market.ts
+++ b/packages/mangrove.js/src/market.ts
@@ -72,8 +72,8 @@ namespace Market {
     slippage?: number;
   } & ({ mangroveOrder?: MangroveOrderParams } | { offerId?: number }) &
     (
-      | { volume: Bigish; price: Bigish | null }
-      | { total: Bigish; price: Bigish | null }
+      | { volume: Bigish; price: Bigish }
+      | { total: Bigish; price: Bigish }
       | { wants: Bigish; gives: Bigish; fillWants?: boolean }
     );
 

--- a/packages/mangrove.js/src/util/trade.ts
+++ b/packages/mangrove.js/src/util/trade.ts
@@ -31,14 +31,11 @@ class Trade {
     if ("price" in params) {
       if ("volume" in params) {
         wants = Big(params.volume);
-        gives =
-          params.price === null
-            ? Big(2).pow(256).minus(1)
-            : wants.mul(params.price);
+        gives = wants.mul(params.price);
         fillWants = true;
       } else {
         gives = Big(params.total);
-        wants = params.price === null ? Big(0) : gives.div(params.price);
+        wants = gives.div(params.price);
         fillWants = false;
       }
     } else {
@@ -65,14 +62,11 @@ class Trade {
     if ("price" in params) {
       if ("volume" in params) {
         gives = Big(params.volume);
-        wants = params.price === null ? Big(0) : gives.mul(params.price);
+        wants = gives.mul(params.price);
         fillWants = false;
       } else {
         wants = Big(params.total);
-        gives =
-          params.price === null
-            ? Big(2).pow(256).minus(1)
-            : wants.div(params.price);
+        gives = wants.div(params.price);
         fillWants = true;
       }
     } else {
@@ -121,8 +115,8 @@ class Trade {
   /**
    * Market buy order. Will attempt to buy base token using quote tokens.
    * Params can be of the form:
-   * - `{volume,price}`: buy `volume` base tokens for a max average price of `price`. Set `price` to null for a true market order. `fillWants` will be true.
-   * - `{total,price}` : buy as many base tokens as possible using up to `total` quote tokens, with a max average price of `price`. Set `price` to null for a true market order. `fillWants` will be false.
+   * - `{volume,price}`: buy `volume` base tokens for a max average price of `price`.
+   * - `{total,price}` : buy as many base tokens as possible using up to `total` quote tokens, with a max average price of `price`.
    * - `{wants,gives,fillWants?}`: accept implicit max average price of `gives/wants`
    *
    * In addition, `slippage` defines an allowed slippage in % of the amount of quote token, and
@@ -194,8 +188,8 @@ class Trade {
   /**
    * Market sell order. Will attempt to sell base token for quote tokens.
    * Params can be of the form:
-   * - `{volume,price}`: sell `volume` base tokens for a min average price of `price`. Set `price` to null for a true market order. `fillWants` will be false.
-   * - `{total,price}` : sell as many base tokens as possible buying up to `total` quote tokens, with a min average price of `price`. Set `price` to null. `fillWants` will be true.
+   * - `{volume,price}`: sell `volume` base tokens for a min average price of `price`.
+   * - `{total,price}` : sell as many base tokens as possible buying up to `total` quote tokens, with a min average price of `price`.
    * - `{wants,gives,fillWants?}`: accept implicit min average price of `gives/wants`. `fillWants` will be false by default.
    *
    * In addition, `slippage` defines an allowed slippage in % of the amount of quote token, and

--- a/packages/mangrove.js/test/integration/market.integration.test.ts
+++ b/packages/mangrove.js/test/integration/market.integration.test.ts
@@ -796,7 +796,7 @@ describe("Market integration tests suite", () => {
 
     // estimated gas limit is too low, so we set it explicitly
     const result = await market.sell(
-      { volume: "0.0000000000000001", price: null },
+      { volume: "0.0000000000000001", price: 0 },
       { gasLimit: 6500000 }
     );
 
@@ -838,7 +838,7 @@ describe("Market integration tests suite", () => {
     const result = await market.buy({
       offerId: notBest,
       total: 1,
-      price: null,
+      price: Big(2).pow(256).minus(1),
     });
     expect(result.tradeFailures).to.have.lengthOf(0);
     expect(result.successes).to.have.lengthOf(1);

--- a/packages/mangrove.js/test/unit/trade.unit.test.ts
+++ b/packages/mangrove.js/test/unit/trade.unit.test.ts
@@ -67,59 +67,6 @@ describe("Trade unit tests suite", () => {
       );
     });
 
-    it("returns wants as volume, gives as Big(2).pow(256).minus(1) and fillWants true, when params has price===null and volume", async function () {
-      //Arrange
-      const trade = new Trade();
-      const spyTrade = spy(trade);
-      const price = null;
-      const slippage = 3;
-      const params: Market.TradeParams = {
-        price: price,
-        volume: 30,
-        slippage: slippage,
-      };
-      const baseToken = mock(MgvToken);
-      const quoteToken = mock(MgvToken);
-      const veryBigNumber = Big(2).pow(256).minus(1);
-      when(baseToken.toUnits(anything())).thenReturn(
-        BigNumber.from(params.volume)
-      );
-      when(quoteToken.toUnits(anything())).thenReturn(
-        BigNumber.from(veryBigNumber.toFixed(0))
-      );
-      when(spyTrade.validateSlippage(slippage)).thenReturn(slippage);
-
-      //Act
-      const result = trade.getParamsForBuy(
-        params,
-        instance(baseToken),
-        instance(quoteToken)
-      );
-      const [wants] = capture(baseToken.toUnits).last();
-      const [gives] = capture(quoteToken.toUnits).last();
-
-      //Assert
-      const expectedGivesWithoutSlippage = veryBigNumber;
-      assert.equal(result.wants.eq(BigNumber.from(params.volume)), true);
-      assert.equal(
-        result.gives.eq(BigNumber.from(veryBigNumber.toFixed(0))),
-        true
-      );
-      assert.equal(result.fillWants, true);
-      assert.equal(Big(params.volume).eq(wants), true);
-      assert.equal(
-        expectedGivesWithoutSlippage
-          .mul(100 + slippage)
-          .div(100)
-          .eq(gives),
-        true
-      );
-      assert.equal(
-        result.givesWithoutSlippage.eq(expectedGivesWithoutSlippage),
-        true
-      );
-    });
-
     it("returns gives as total, wants as gives.div(price) and fillWants false, when params has price!=null and total", async function () {
       //Arrange
       const trade = new Trade();
@@ -164,58 +111,6 @@ describe("Trade unit tests suite", () => {
       );
       assert.equal(result.fillWants, false);
       assert.equal(Big(params.total).div(price).eq(wants), true);
-      assert.equal(
-        expectedGivesWithoutSlippage
-          .mul(100 + slippage)
-          .div(100)
-          .eq(gives),
-        true
-      );
-      assert.equal(
-        result.givesWithoutSlippage.eq(expectedGivesWithoutSlippage),
-        true
-      );
-    });
-
-    it("returns gives as total, wants as Big(0) and fillWants false, when params has price===null and total", async function () {
-      //Arrange
-      const trade = new Trade();
-      const spyTrade = spy(trade);
-      const price = null;
-      const slippage = 3;
-      const params: Market.TradeParams = {
-        price: price,
-        total: 30,
-        slippage: slippage,
-      };
-      const baseToken = mock(MgvToken);
-      const quoteToken = mock(MgvToken);
-      when(baseToken.toUnits(anything())).thenReturn(
-        BigNumber.from(Big(0).toFixed(0))
-      );
-      when(quoteToken.toUnits(anything())).thenReturn(
-        BigNumber.from(params.total)
-      );
-      when(spyTrade.validateSlippage(slippage)).thenReturn(slippage);
-
-      //Act
-      const result = trade.getParamsForBuy(
-        params,
-        instance(baseToken),
-        instance(quoteToken)
-      );
-      const [wants] = capture(baseToken.toUnits).last();
-      const [gives] = capture(quoteToken.toUnits).last();
-
-      //Assert
-      const expectedGivesWithoutSlippage = Big(params.total);
-      assert.equal(
-        result.gives.eq(BigNumber.from(Big(params.total).toFixed(0))),
-        true
-      );
-      assert.equal(result.wants.eq(BigNumber.from(Big(0).toFixed(0))), true);
-      assert.equal(result.fillWants, false);
-      assert.equal(Big(0).eq(wants), true);
       assert.equal(
         expectedGivesWithoutSlippage
           .mul(100 + slippage)
@@ -394,55 +289,6 @@ describe("Trade unit tests suite", () => {
       );
     });
 
-    it("returns gives as volume, wants as Big(0) and fillWants false, when params has price===null and volume", async function () {
-      //Arrange
-      const trade = new Trade();
-      const spyTrade = spy(trade);
-      const price = null;
-      const slippage = 3;
-      const params: Market.TradeParams = {
-        price: price,
-        volume: 30,
-        slippage: slippage,
-      };
-      const baseToken = mock(MgvToken);
-      const quoteToken = mock(MgvToken);
-      when(baseToken.toUnits(anything())).thenReturn(
-        BigNumber.from(params.volume)
-      );
-      when(quoteToken.toUnits(anything())).thenReturn(
-        BigNumber.from(Big(0).toFixed(0))
-      );
-      when(spyTrade.validateSlippage(slippage)).thenReturn(slippage);
-
-      //Act
-      const result = trade.getParamsForSell(
-        params,
-        instance(baseToken),
-        instance(quoteToken)
-      );
-      const [gives] = capture(baseToken.toUnits).last();
-      const [wants] = capture(quoteToken.toUnits).last();
-
-      //Assert
-      const expectedWantsWithoutSlippage = Big(0);
-      assert.equal(result.wants.eq(BigNumber.from(Big(0).toFixed(0))), true);
-      assert.equal(
-        result.wantsWithoutSlippage.eq(expectedWantsWithoutSlippage),
-        true
-      );
-      assert.equal(result.gives.eq(BigNumber.from(params.volume)), true);
-      assert.equal(result.fillWants, false);
-      assert.equal(Big(params.volume).eq(gives), true);
-      assert.equal(
-        expectedWantsWithoutSlippage
-          .mul(100 - slippage)
-          .div(100)
-          .eq(wants),
-        true
-      );
-    });
-
     it("returns wants as total, gives as wants.div(price) and fillWants true, when params has price!=null and total", async function () {
       //Arrange
       const trade = new Trade();
@@ -491,61 +337,6 @@ describe("Trade unit tests suite", () => {
       );
       assert.equal(result.fillWants, true);
       assert.equal(Big(params.total).div(price).eq(gives), true);
-      assert.equal(
-        expectedWantsWithoutSlippage
-          .mul(100 - slippage)
-          .div(100)
-          .eq(wants),
-        true
-      );
-    });
-
-    it("returns wants as total, gives as Big(2).pow(256).minus(1) and fillWants true, when params has price===null and total", async function () {
-      //Arrange
-      const trade = new Trade();
-      const spyTrade = spy(trade);
-      const price = null;
-      const slippage = 3;
-      const params: Market.TradeParams = {
-        price: price,
-        total: 30,
-        slippage: slippage,
-      };
-      const baseToken = mock(MgvToken);
-      const quoteToken = mock(MgvToken);
-      when(quoteToken.toUnits(anything())).thenReturn(
-        BigNumber.from(params.total)
-      );
-      when(baseToken.toUnits(anything())).thenReturn(
-        BigNumber.from(Big(2).pow(256).minus(1).toFixed(0))
-      );
-      when(spyTrade.validateSlippage(slippage)).thenReturn(slippage);
-
-      //Act
-      const result = trade.getParamsForSell(
-        params,
-        instance(baseToken),
-        instance(quoteToken)
-      );
-      const [gives] = capture(baseToken.toUnits).last();
-      const [wants] = capture(quoteToken.toUnits).last();
-
-      //Assert
-      const expectedWantsWithoutSlippage = Big(params.total);
-      assert.equal(
-        result.wants.eq(BigNumber.from(Big(params.total).toFixed(0))),
-        true
-      );
-      assert.equal(
-        result.wantsWithoutSlippage.eq(expectedWantsWithoutSlippage),
-        true
-      );
-      assert.equal(
-        result.gives.eq(BigNumber.from(Big(2).pow(256).minus(1).toFixed(0))),
-        true
-      );
-      assert.equal(result.fillWants, true);
-      assert.equal(Big(2).pow(256).minus(1).eq(gives), true);
       assert.equal(
         expectedWantsWithoutSlippage
           .mul(100 - slippage)


### PR DESCRIPTION
`market.{buy|sell}` allowed `price` to be set to `null` which meant "accept any price" (= simulate a market order). This is dangerous, as such tx's are likely to be sandwich attacked:

1. Attacker borrows liquidity to front-run the victim
2. Attacker buys/sells the requested volume on Mangrove and inserts an offer at the top of the book with the requested volume and a price that is just a tiny bit better than the remainder on the book
3. Victim's tx is executed and buys the attacker's offer
4. Attacker repays the loan and pockets the difference between the borrowed amount and what the victim paid.

While we cannot prevent users from sending such orders, it should not be encouraged in the API. Therefore this commit removes the feature.

At a later stage we can add safer semantics for price=null. Eg to estimate the avg price for the order based on the cache and then use that price. See issue #871.