### PR TITLE
fix(test): Make proxy between tests and anvil to allow closure

### DIFF
--- a/packages/bot-cleaning/test/integration/marketCleaner.integration.test.ts
+++ b/packages/bot-cleaning/test/integration/marketCleaner.integration.test.ts
@@ -28,15 +28,12 @@ let mgv: Mangrove;
 let market: Market;
 
 describe("MarketCleaner integration tests", () => {
-  before(async function () {
-    testProvider = ethers.getDefaultProvider(this.server.url);
-  });
-
   after(async function () {
     await mgvTestUtil.logAddresses();
   });
 
   beforeEach(async function () {
+    testProvider = ethers.getDefaultProvider(this.server.url);
     mgvTestUtil.setConfig(
       await Mangrove.connect({
         privateKey: this.accounts.deployer.key,

--- a/packages/bot-failing-offer/test/integration/failingOffer.integration.test.ts
+++ b/packages/bot-failing-offer/test/integration/failingOffer.integration.test.ts
@@ -28,15 +28,8 @@ let makerMarket: Market;
 let cleanerMarket: Market;
 
 describe("Failing offer integration tests", () => {
-  before(async function () {
-    testProvider = ethers.getDefaultProvider(this.server.url);
-  });
-
-  after(async function () {
-    await mgvTestUtil.logAddresses();
-  });
-
   beforeEach(async function () {
+    testProvider = ethers.getDefaultProvider(this.server.url);
     makerMangrove = await Mangrove.connect({
       privateKey: this.accounts.maker.key,
       provider: this.server.url,

--- a/packages/bot-template/test/integration/templateBot.integration.test.ts
+++ b/packages/bot-template/test/integration/templateBot.integration.test.ts
@@ -27,11 +27,8 @@ describe("Bot integration tests", () => {
   let botSigner: Signer;
   let mgv: Mangrove;
 
-  before(async function () {
-    botSigner = new ethers.Wallet(this.accounts.tester.key);
-  });
-
   beforeEach(async function () {
+    botSigner = new ethers.Wallet(this.accounts.tester.key);
     // specific to this bot
     mgv = await Mangrove.connect({
       signer: botSigner,

--- a/packages/bot-updategas/test/integration/gasUpdater.integration.test.ts
+++ b/packages/bot-updategas/test/integration/gasUpdater.integration.test.ts
@@ -20,12 +20,9 @@ describe("GasUpdater integration tests", () => {
   let mgv: Mangrove;
   let mgvAdmin: Mangrove;
 
-  before(async function () {
+  beforeEach(async function () {
     gasUpdaterSigner = new ethers.Wallet(this.accounts.tester.key);
     // gasUpdaterSigner = await hre.ethers.getNamedSigner("gasUpdater");
-  });
-
-  beforeEach(async function () {
     mgv = await Mangrove.connect({
       //provider: this.test?.parent?.parent?.ctx.provider,
       signer: gasUpdaterSigner,

--- a/packages/mangrove.js/package.json
+++ b/packages/mangrove.js/package.json
@@ -101,6 +101,7 @@
     "prettier": "^2.4.1",
     "rimraf": "^3.0.2",
     "shx": "^0.3.4",
+    "transparent-proxy": "^1.9.1",
     "ts-essentials": "^9.1.2",
     "ts-mockito": "^2.0.0",
     "ts-node": "^10.9.1",

--- a/packages/mangrove.js/src/util/node.ts
+++ b/packages/mangrove.js/src/util/node.ts
@@ -330,27 +330,15 @@ const connect = async (params: {
     params,
     snapshot: async () => {
       lastSnapshotId = await params.provider.send("evm_snapshot", []);
-
-      const bn = await params.provider.perform("getBlockNumber", {});
-
-      snapshotBlockNumber = BigNumber.from(bn).toNumber();
+      snapshotBlockNumber = await params.provider.getBlockNumber();
       return lastSnapshotId;
     },
     revert: async (snapshotId = lastSnapshotId) => {
-      let poolStatus = await params.provider.send("txpool_status", []);
-      while (poolStatus.pending != "0x0" || poolStatus.queued != "0x0") {
-        console.log(poolStatus);
-        poolStatus = await params.provider.send("txpool_status", []);
-      }
-
       await params.provider.send("evm_revert", [snapshotId]);
-
-      const bn = await params.provider.perform("getBlockNumber", {});
-
-      const blockNumberAfterRevert = BigNumber.from(bn).toNumber();
+      const blockNumberAfterRevert = await params.provider.getBlockNumber();
       if (blockNumberAfterRevert != snapshotBlockNumber) {
         throw Error(
-          `evm_revert aadid not revert to expected block number ${snapshotBlockNumber} but to ${blockNumberAfterRevert}. Snapshots are deleted when reverting - did you take a new snapshot after the last revert?`
+          `evm_revert did not revert to expected block number ${snapshotBlockNumber} but to ${blockNumberAfterRevert}. Snapshots are deleted when reverting - did you take a new snapshot after the last revert?`
         );
       }
     },

--- a/packages/mangrove.js/src/util/test/mgvIntegrationTestUtil.ts
+++ b/packages/mangrove.js/src/util/test/mgvIntegrationTestUtil.ts
@@ -244,6 +244,11 @@ export let eventsForLastTxHaveBeenGeneratedPromise: Promise<void>;
 export async function waitForBooksForLastTx(market?: Market) {
   // Wait for txs so we can get the right block number for them
   await eventsForLastTxHaveBeenGenerated();
+  if (!isTrackingPolls) {
+    throw Error(
+      "call initPollOfTransactionTracking before trying to await waitForBooksForLastTx"
+    );
+  }
   if (market) {
     // this may be a block number slightly larger, but for tests that is ok.
     const lastBlock = await market.mgv._provider.getBlockNumber();

--- a/packages/mangrove.js/src/util/test/mochaHooks.ts
+++ b/packages/mangrove.js/src/util/test/mochaHooks.ts
@@ -88,7 +88,7 @@ export const mochaHooks = {
     currentProxyPort++;
     newProxy.proxyServer = new ProxyServer({
       upstream: async function () {
-        return "127.0.0.1:8545";
+        return `http://${serverParams.host}:${serverParams.port}`;
       },
       intercept: true,
       injectData: (data: any, session: any) => {
@@ -101,11 +101,11 @@ export const mochaHooks = {
         return data;
       },
     });
-    newProxy.proxyServer.listen(currentProxyPort, "127.0.0.1");
+    newProxy.proxyServer.listen(currentProxyPort, serverParams.host);
     this.proxies[currentProxyPort] = newProxy;
     // Tests reference the anvil instance through the following address.
     // Note, this is updated on this global instance, so a test should never read it inside an non-awaited async request
-    this.server.url = `http://127.0.0.1:${currentProxyPort}`;
+    this.server.url = `http://${serverParams.host}:${currentProxyPort}`;
 
     await this.server.revert();
     // revert removes the old snapshot, a new snapshot is therefore needed. https://github.com/foundry-rs/foundry/blob/6262fbec64021463fd403204039201983effa00d/evm/src/executor/fork/database.rs#L117

--- a/yarn.lock
+++ b/yarn.lock
@@ -1807,6 +1807,7 @@ __metadata:
     prettier: ^2.4.1
     rimraf: ^3.0.2
     shx: ^0.3.4
+    transparent-proxy: ^1.9.1
     ts-essentials: ^9.1.2
     ts-mockito: ^2.0.0
     ts-node: ^10.9.1
@@ -7597,6 +7598,13 @@ fsevents@~2.3.2:
   version: 1.0.1
   resolution: "toidentifier@npm:1.0.1"
   checksum: 952c29e2a85d7123239b5cfdd889a0dde47ab0497f0913d70588f19c53f7e0b5327c95f4651e413c74b785147f9637b17410ac8c846d5d4a20a5a33eb6dc3a45
+  languageName: node
+  linkType: hard
+
+"transparent-proxy@npm:^1.9.1":
+  version: 1.9.1
+  resolution: "transparent-proxy@npm:1.9.1"
+  checksum: b820f94084a29e5e899ff438ec8ea46934130f5791d4af6d39f09aed563133aad4744b8729c43d4219b8c2339d160a1deb97ac00768763c1f9aa86c4291b1206
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Integration tests run against an anvil instance. We use snapshots and in `beforeEach` we revert to a previous, good, snapshot before starting each test.

However, the prior test can have outstanding RPC requests towards the anvil instance and these can complete _after_ the revert, causing changes to anvil state.

We now proxy all requests through a proxy and close it for further requests and wait for outstanding requests before reverting.

This fixes sporadic test failures like
https://github.com/mangrovedao/mangrove-ts/actions/runs/3410881559/jobs/5674398420
and
https://github.com/mangrovedao/mangrove-ts/actions/runs/3411610454/jobs/5676045661
where revert does not do its job.


An alternative fix would be to figure out why we have outstanding requests - but they should not make random tests fail.
Also, we could consider a feature in anvil where it can close connections/switch ports.
Spinning up a new anvil instance defeats the purpose of fast execution of tests.