### PR TITLE
ci: Add missing permission

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -184,6 +184,9 @@ jobs:
       run:
         working-directory: ${{env.working-directory}}
 
+    permissions:
+      checks: write
+
     strategy:
       matrix:
         node-version: [16.x]


### PR DESCRIPTION
dorny test-reporter now requires the 'checks' write permission, see https://github.com/dorny/test-reporter/issues/229

It seems to have been the case for a while, but for some reason missing permissions are now breaking the build. It might be related to the other weird issues we've seen with Dependabot commits recently.