### PR TITLE
feat(Kandel): Enable retrieval of recommended configuration for Kandel instances

### DIFF
--- a/packages/mangrove.js/src/constants/kandelConfiguration.json
+++ b/packages/mangrove.js/src/constants/kandelConfiguration.json
@@ -1,0 +1,38 @@
+{
+  "gaspriceFactor": 10,
+  "maxOffersInPopulateChunk": 50,
+  "maxOffersInRetractChunk": 50,
+  "aaveEnabled": false,
+  "spread": 1,
+  "ratio": 1.01,
+  "networks": {
+    "maticmum": {
+      "gasPriceFactor": 10,
+      "maxOffersInPopulateChunk": 80,
+      "maxOffersInRetractChunk": 80,
+      "aaveEnabled": true,
+      "markets": {
+        "WETH": {
+          "USDC": { "minimumBasePerOffer": 1, "minimumQuotePerOffer": 1 }
+        },
+        "USDC": {
+          "USDT": {
+            "minimumBasePerOffer": 1,
+            "minimumQuotePerOffer": 1,
+            "ratio": 1.001
+          }
+        },
+        "WMATIC": {
+          "WETH": { "minimumBasePerOffer": 1, "minimumQuotePerOffer": 1 }
+        }
+      }
+    },
+    "local": {
+      "markets": {
+        "TokenA": {
+          "TokenB": { "minimumBasePerOffer": 1, "minimumQuotePerOffer": 1 }
+        }
+      }
+    }
+  }
+}

--- a/packages/mangrove.js/src/constants/kandelConfiguration.json
+++ b/packages/mangrove.js/src/constants/kandelConfiguration.json
@@ -13,24 +13,33 @@
       "aaveEnabled": true,
       "markets": {
         "WETH": {
-          "USDC": { "minimumBasePerOffer": 1, "minimumQuotePerOffer": 1 }
+          "USDC": {
+            "minimumBasePerOfferFactor": 10,
+            "minimumQuotePerOfferFactor": 10
+          }
         },
         "USDC": {
           "USDT": {
-            "minimumBasePerOffer": 1,
-            "minimumQuotePerOffer": 1,
+            "minimumBasePerOfferFactor": 10,
+            "minimumQuotePerOfferFactor": 10,
             "ratio": 1.001
           }
         },
         "WMATIC": {
-          "WETH": { "minimumBasePerOffer": 1, "minimumQuotePerOffer": 1 }
+          "WETH": {
+            "minimumBasePerOfferFactor": 10,
+            "minimumQuotePerOfferFactor": 10
+          }
         }
       }
     },
     "local": {
       "markets": {
         "TokenA": {
-          "TokenB": { "minimumBasePerOffer": 1, "minimumQuotePerOffer": 1 }
+          "TokenB": {
+            "minimumBasePerOfferFactor": 10,
+            "minimumQuotePerOfferFactor": 10
+          }
         }
       }
     }

--- a/packages/mangrove.js/src/kandel/kandelConfiguration.ts
+++ b/packages/mangrove.js/src/kandel/kandelConfiguration.ts
@@ -16,15 +16,15 @@ export type NetworkConfiguration = {
 
 /** Configuration for a specific market.
  * @param aaveEnabled Whether AaveKandel should be allowed to be used.
- * @param minimumBasePerOffer The minimum amount of base token that should be offered per offer to stay above density requirements.
- * @param minimumQuotePerOffer The minimum amount of quote token that should be offered per offer to stay above density requirements.
+ * @param minimumBasePerOfferFactor Additional factor for the minimum amount of base token that should be offered per offer to stay above density requirements.
+ * @param minimumQuotePerOfferFactor Additional factor for the minimum amount of quote token that should be offered per offer to stay above density requirements.
  * @param spread The default spread used when transporting funds from an offer to its dual.
  * @param ratio The default ratio of the geometric progression of prices.
  */
 export type MarketConfiguration = {
   aaveEnabled: boolean;
-  minimumBasePerOffer: Big;
-  minimumQuotePerOffer: Big;
+  minimumBasePerOfferFactor: Big;
+  minimumQuotePerOfferFactor: Big;
   spread: number;
   ratio: Big;
 };
@@ -71,11 +71,11 @@ class KandelConfiguration {
         config.aaveEnabled !== undefined && config.aaveEnabled !== null
           ? Boolean(config.aaveEnabled)
           : undefined,
-      minimumBasePerOffer: config.minimumBasePerOffer
-        ? new Big(config.minimumBasePerOffer)
+      minimumBasePerOfferFactor: config.minimumBasePerOfferFactor
+        ? new Big(config.minimumBasePerOfferFactor)
         : undefined,
-      minimumQuotePerOffer: config.minimumQuotePerOffer
-        ? new Big(config.minimumQuotePerOffer)
+      minimumQuotePerOfferFactor: config.minimumQuotePerOfferFactor
+        ? new Big(config.minimumQuotePerOfferFactor)
         : undefined,
       spread: config.spread ? Number(config.spread) : undefined,
       ratio: config.ratio ? new Big(config.ratio) : undefined,
@@ -110,12 +110,12 @@ class KandelConfiguration {
         config.aaveEnabled !== undefined && config.aaveEnabled !== null
           ? config.aaveEnabled
           : thrower(`aaveEnabled is not configured`),
-      minimumBasePerOffer:
-        config.minimumBasePerOffer ??
-        thrower(`minimumBasePerOffer is not configured`),
-      minimumQuotePerOffer:
-        config.minimumQuotePerOffer ??
-        thrower(`minimumQuotePerOffer is not configured`),
+      minimumBasePerOfferFactor:
+        config.minimumBasePerOfferFactor ??
+        thrower(`minimumBasePerOfferFactor is not configured`),
+      minimumQuotePerOfferFactor:
+        config.minimumQuotePerOfferFactor ??
+        thrower(`minimumQuotePerOfferFactor is not configured`),
       spread: config.spread ?? thrower(`spread is not configured`),
       ratio: config.ratio ?? thrower(`ratio is not configured`),
     };

--- a/packages/mangrove.js/src/kandel/kandelConfiguration.ts
+++ b/packages/mangrove.js/src/kandel/kandelConfiguration.ts
@@ -1,0 +1,165 @@
+import Big from "big.js";
+import Market from "../market";
+import kandelConfiguration from "../constants/kandelConfiguration.json";
+import Mangrove from "../mangrove";
+
+/** Configuration for a specific chain.
+ * @param gaspriceFactor The factor to multiply the gasprice by. This is used to ensure that the Kandel offers do not fail to be reposted even if Mangrove's gasprice increases up to this.
+ * @param maxOffersInPopulateChunk The maximum number of offers to include in a single populate transaction to avoid exceeding the gas limit.
+ * @param maxOffersInRetractChunk The maximum number of offers to include in a single retract transaction to avoid exceeding the gas limit.
+ */
+export type NetworkConfiguration = {
+  gaspriceFactor: number;
+  maxOffersInPopulateChunk: number;
+  maxOffersInRetractChunk: number;
+};
+
+/** Configuration for a specific market.
+ * @param aaveEnabled Whether AaveKandel should be allowed to be used.
+ * @param minimumBasePerOffer The minimum amount of base token that should be offered per offer to stay above density requirements.
+ * @param minimumQuotePerOffer The minimum amount of quote token that should be offered per offer to stay above density requirements.
+ * @param spread The default spread used when transporting funds from an offer to its dual.
+ * @param ratio The default ratio of the geometric progression of prices.
+ */
+export type MarketConfiguration = {
+  aaveEnabled: boolean;
+  minimumBasePerOffer: Big;
+  minimumQuotePerOffer: Big;
+  spread: number;
+  ratio: Big;
+};
+
+/** @title Provides recommended configuration for deploying Kandel instances. */
+class KandelConfiguration {
+  rawConfiguration: any;
+
+  /** Constructor to provide specific configuration.
+   * @param configurationOverride The configuration to use instead of reading kandelConfiguration.json.
+   */
+  public constructor(configurationOverride?: any) {
+    this.rawConfiguration = configurationOverride ?? kandelConfiguration;
+  }
+
+  /** Gets the most specific available config for the network and the base/quote pair.
+   * @param networkName The name of the network.
+   * @param baseName The name of the base token.
+   * @param quoteName The name of the quote token.
+   * @returns The most specific configuration available for the network and the base/quote pair.
+   */
+  public getMostSpecificConfig(
+    networkName: string,
+    baseName: string,
+    quoteName: string
+  ): NetworkConfiguration & Partial<MarketConfiguration> {
+    const networkSpecificConfig = this.rawConfiguration.networks[networkName];
+    const baseSpecificConfig = networkSpecificConfig?.markets[baseName];
+    const marketSpecificConfig = baseSpecificConfig
+      ? baseSpecificConfig[quoteName]
+      : undefined;
+
+    const config = {
+      ...this.rawConfiguration,
+      ...networkSpecificConfig,
+      ...marketSpecificConfig,
+    };
+
+    return {
+      gaspriceFactor: Number(config.gaspriceFactor),
+      maxOffersInPopulateChunk: Number(config.maxOffersInPopulateChunk),
+      maxOffersInRetractChunk: Number(config.maxOffersInRetractChunk),
+      aaveEnabled:
+        config.aaveEnabled !== undefined && config.aaveEnabled !== null
+          ? Boolean(config.aaveEnabled)
+          : undefined,
+      minimumBasePerOffer: config.minimumBasePerOffer
+        ? new Big(config.minimumBasePerOffer)
+        : undefined,
+      minimumQuotePerOffer: config.minimumQuotePerOffer
+        ? new Big(config.minimumQuotePerOffer)
+        : undefined,
+      spread: config.spread ? Number(config.spread) : undefined,
+      ratio: config.ratio ? new Big(config.ratio) : undefined,
+    };
+  }
+
+  /** Gets the config for the network and the base/quote pair.
+   * @param networkName The name of the network.
+   * @param baseName The name of the base token.
+   * @param quoteName The name of the quote token.
+   * @returns The configuration for the network and the base/quote pair.
+   * @throws If the full config is not available for the network and the base/quote pair.
+   */
+  public getConfigForBaseQuote(
+    networkName: string,
+    baseName: string,
+    quoteName: string
+  ): NetworkConfiguration & MarketConfiguration {
+    const config = this.getMostSpecificConfig(networkName, baseName, quoteName);
+
+    function thrower(msg: string): never {
+      throw new Error(
+        `${msg} for pair ${baseName}/${quoteName} on network ${networkName}.`
+      );
+    }
+
+    return {
+      gaspriceFactor: config.gaspriceFactor,
+      maxOffersInPopulateChunk: config.maxOffersInPopulateChunk,
+      maxOffersInRetractChunk: config.maxOffersInRetractChunk,
+      aaveEnabled:
+        config.aaveEnabled !== undefined && config.aaveEnabled !== null
+          ? config.aaveEnabled
+          : thrower(`aaveEnabled is not configured`),
+      minimumBasePerOffer:
+        config.minimumBasePerOffer ??
+        thrower(`minimumBasePerOffer is not configured`),
+      minimumQuotePerOffer:
+        config.minimumQuotePerOffer ??
+        thrower(`minimumQuotePerOffer is not configured`),
+      spread: config.spread ?? thrower(`spread is not configured`),
+      ratio: config.ratio ?? thrower(`ratio is not configured`),
+    };
+  }
+
+  /** Gets the config for the market.
+   * @param market The market.
+   * @returns The configuration for the market.
+   * @throws If the full config is not available for the market.
+   */
+  public getConfig(market: Market): NetworkConfiguration & MarketConfiguration {
+    return this.getConfigForBaseQuote(
+      market.mgv.network.name,
+      market.base.name,
+      market.quote.name
+    );
+  }
+
+  /** Gets the list of markets that are configured for the network for the given Mangrove instance.
+   * @param mgv The Mangrove instance.
+   * @returns The list of markets that are configured for the network for the given Mangrove instance.
+   */
+  public getConfiguredMarkets(mgv: Mangrove) {
+    return this.getConfiguredMarketsForNetwork(mgv.network.name);
+  }
+
+  /** Gets the list of markets that are configured for the network.
+   * @param networkName The name of the network.
+   * @returns The list of markets that are configured for the network.
+   */
+  public getConfiguredMarketsForNetwork(
+    networkName: string
+  ): { base: string; quote: string }[] {
+    return Object.entries(
+      this.rawConfiguration.networks[networkName]?.markets ?? []
+    ).flatMap(([base, quotes]) => {
+      return Object.keys(quotes).map((quote) => ({ base, quote }));
+    });
+  }
+
+  /** Gets the networks with some configuration. */
+  public getNetworks() {
+    return Object.keys(this.rawConfiguration.networks);
+  }
+}
+
+export default KandelConfiguration;

--- a/packages/mangrove.js/src/kandel/kandelDistribution.ts
+++ b/packages/mangrove.js/src/kandel/kandelDistribution.ts
@@ -81,14 +81,16 @@ class KandelDistribution {
    * @returns The amount of base or quote to give for each offer.
    */
   public calculateConstantGivesPerOffer(
-    availableBase: Big,
+    availableBase?: Big,
     availableQuote?: Big
   ) {
     const bids = this.offers.filter((x) => x.offerType == "bids").length;
     const asks = this.offers.filter((x) => x.offerType == "asks").length;
 
     return {
-      askGives: this.calculateOfferGives("asks", asks, availableBase),
+      askGives: availableBase
+        ? this.calculateOfferGives("asks", asks, availableBase)
+        : undefined,
       bidGives: availableQuote
         ? this.calculateOfferGives("bids", bids, availableQuote)
         : undefined,

--- a/packages/mangrove.js/src/kandel/kandelDistributionGenerator.ts
+++ b/packages/mangrove.js/src/kandel/kandelDistributionGenerator.ts
@@ -26,8 +26,8 @@ class KandelDistributionGenerator {
    * @param params.midPrice The mid-price used to determine when to switch from bids to asks.
    * @param params.constantBase Whether the base amount should be constant for all offers.
    * @param params.constantQuote Whether the quote amount should be constant for all offers.
-   * @param params.minimumBasePerOffer The minimum amount of base to give for each offer. Should be at least minimumBasePerOffer from KandelConfiguration for the market.
-   * @param params.minimumQuotePerOffer The minimum amount of quote to give for each offer. Should be at least minimumQuotePerOffer from KandelConfiguration for the market.
+   * @param params.minimumBasePerOffer The minimum amount of base to give for each offer. Should be at least minimumBasePerOfferFactor from KandelConfiguration multiplied with the minimum volume for the market.
+   * @param params.minimumQuotePerOffer The minimum amount of quote to give for each offer. Should be at least minimumQuotePerOfferFactor from KandelConfiguration multiplied with the minimum volume for the market.
    * @returns The distribution of bids and asks and their base and quote amounts.
    * @remarks The price distribution may not match the priceDistributionParams exactly due to limited precision.
    */
@@ -66,8 +66,8 @@ class KandelDistributionGenerator {
    * @param params The parameters for the geometric distribution.
    * @param params.priceParams The parameters for the geometric price distribution.
    * @param params.midPrice The mid-price used to determine when to switch from bids to asks.
-   * @param params.initialAskGives The initial amount of base to give for all asks. Should be at least minimumBasePerOffer from KandelConfiguration for the market. If not provided, then initialBidGives is used as quote for asks, and the base the ask gives is set to according to the price.
-   * @param params.initialBidGives The initial amount of quote to give for all bids. Should be at least minimumQuotePerOffer from KandelConfiguration for the market. If not provided, then initialAskGives is used as base for bids, and the quote the bid gives is set to according to the price.
+   * @param params.initialAskGives The initial amount of base to give for all asks. Should be at least minimumBasePerOfferFactor from KandelConfiguration multiplied with the minimum volume for the market. If not provided, then initialBidGives is used as quote for asks, and the base the ask gives is set to according to the price.
+   * @param params.initialBidGives The initial amount of quote to give for all bids. Should be at least minimumQuotePerOfferFactor from KandelConfiguration multiplied with the minimum volume for the market. If not provided, then initialAskGives is used as base for bids, and the quote the bid gives is set to according to the price.
    * @returns The distribution of bids and asks and their base and quote amounts.
    * @remarks The price distribution may not match the priceDistributionParams exactly due to limited precision.
    */
@@ -100,7 +100,7 @@ class KandelDistributionGenerator {
    * @param params.availableQuote The available quote to consume. If not provided, then the base for asks is also used as base for bids, and the quote the bid gives is set to according to the price.
    * @returns The distribution of bids and asks and their base and quote amounts.
    * @remarks The required volume can be slightly less than available due to rounding due to token decimals.
-   * @remarks Note that the resulting offered volume for each offer should be at least minimumBasePerOffer and minimumQuotePerOffer from KandelConfiguration for the market.
+   * @remarks Note that the resulting offered base volume for each offer should be at least minimumBasePerOfferFactor from KandelConfiguration multiplied with the minimum volume for the market - and similar for quote.
    */
   public recalculateDistributionFromAvailable(params: {
     distribution: KandelDistribution;

--- a/packages/mangrove.js/src/kandel/kandelDistributionGenerator.ts
+++ b/packages/mangrove.js/src/kandel/kandelDistributionGenerator.ts
@@ -24,15 +24,15 @@ class KandelDistributionGenerator {
    * @param params The parameters for the geometric distribution.
    * @param params.priceParams The parameters for the geometric price distribution.
    * @param params.midPrice The mid-price used to determine when to switch from bids to asks.
-   * @param params.initialAskGives The initial amount of base to give for all asks.
-   * @param params.initialBidGives The initial amount of quote to give for all bids. If not provided, then initialAskGives is used as base for bids, and the quote the bid gives is set to according to the price.
-   * @returns The distribution of bids and asks and their base and quote amounts along with the required volume of base and quote for the distribution to be fully provisioned.
+   * @param params.initialAskGives The initial amount of base to give for all asks. Should be at least minimumBasePerOffer from KandelConfiguration for the market. If not provided, then initialBidGives is used as quote for asks, and the base the ask gives is set to according to the price.
+   * @param params.initialBidGives The initial amount of quote to give for all bids. Should be at least minimumQuotePerOffer from KandelConfiguration for the market. If not provided, then initialAskGives is used as base for bids, and the quote the bid gives is set to according to the price.
+   * @returns The distribution of bids and asks and their base and quote amounts.
    * @remarks The price distribution may not match the priceDistributionParams exactly due to limited precision.
    */
   public calculateDistribution(params: {
     priceParams: PriceDistributionParams;
     midPrice: Bigish;
-    initialAskGives: Bigish;
+    initialAskGives?: Bigish;
     initialBidGives?: Bigish;
   }) {
     const pricesAndRatio = this.priceCalculation.calculatePrices(
@@ -46,7 +46,7 @@ class KandelDistributionGenerator {
       pricesAndRatio.ratio,
       pricesAndRatio.prices,
       firstAskIndex,
-      Big(params.initialAskGives),
+      params.initialAskGives ? Big(params.initialAskGives) : undefined,
       params.initialBidGives ? Big(params.initialBidGives) : undefined
     );
   }
@@ -54,18 +54,19 @@ class KandelDistributionGenerator {
   /** Recalculates the gives for offers in the distribution such that the available base and quote is consumed uniformly, while preserving the price distribution.
    * @param params The parameters for the recalculation.
    * @param params.distribution The distribution to reset the gives for.
-   * @param params.availableBase The available base to consume.
+   * @param params.availableBase The available base to consume. If not provided, then the quote for bids is also used as quote for asks, and the base the ask gives is set to according to the price.
    * @param params.availableQuote The available quote to consume. If not provided, then the base for asks is also used as base for bids, and the quote the bid gives is set to according to the price.
-   * @returns The distribution of bids and asks and their base and quote amounts along with the required volume of base and quote for the distribution to be fully provisioned.
+   * @returns The distribution of bids and asks and their base and quote amounts.
    * @remarks The required volume can be slightly less than available due to rounding due to token decimals.
+   * @remarks Note that the resulting offered volume for each offer should be at least minimumBasePerOffer and minimumQuotePerOffer from KandelConfiguration for the market.
    */
   public recalculateDistributionFromAvailable(params: {
     distribution: KandelDistribution;
-    availableBase: Bigish;
+    availableBase?: Bigish;
     availableQuote?: Bigish;
   }) {
     const initialGives = params.distribution.calculateConstantGivesPerOffer(
-      Big(params.availableBase),
+      params.availableBase ? Big(params.availableBase) : undefined,
       params.availableQuote ? Big(params.availableQuote) : undefined
     );
 

--- a/packages/mangrove.js/src/kandel/kandelDistributionHelper.ts
+++ b/packages/mangrove.js/src/kandel/kandelDistributionHelper.ts
@@ -201,6 +201,49 @@ class KandelDistributionHelper {
     return distribution;
   }
 
+  /** Calculates the minimum initial gives for each offer such that all possible gives of fully taken offers at all price points will be above the minimums provided.
+   * @param prices The price distribution.
+   * @param minimumBasePerOffer The minimum base to give for each offer.
+   * @param minimumQuotePerOffer The minimum quote to give for each offer.
+   * @returns The minimum initial gives for each offer such that all possible gives of fully taken offers at all price points will be above the minimums provided.
+   */
+  calculateInitialGives(
+    prices: Big[],
+    minimumBasePerOffer: Big,
+    minimumQuotePerOffer: Big
+  ) {
+    if (prices.length == 0)
+      return { askGives: minimumBasePerOffer, bidGives: minimumQuotePerOffer };
+
+    let minPrice = prices[0];
+    let maxPrice = prices[0];
+    prices.forEach((p) => {
+      if (p.lt(minPrice)) {
+        minPrice = p;
+      }
+      if (p.gt(maxPrice)) {
+        maxPrice = p;
+      }
+    });
+
+    const minimumBaseFromQuote = this.baseFromQuoteAndPrice(
+      minimumQuotePerOffer,
+      minPrice
+    );
+    const minimumQuoteFromBase = this.quoteFromBaseAndPrice(
+      minimumBasePerOffer,
+      maxPrice
+    );
+    const askGives = minimumBaseFromQuote.gt(minimumBasePerOffer)
+      ? minimumBaseFromQuote
+      : minimumBasePerOffer;
+    const bidGives = minimumQuoteFromBase.gt(minimumQuotePerOffer)
+      ? minimumQuoteFromBase
+      : minimumQuotePerOffer;
+
+    return { askGives, bidGives };
+  }
+
   /** Creates a distribution based on an explicit set of offers. Either based on an original distribution or parameters for one.
    * @param explicitOffers The explicit offers to use.
    * @param explicitOffers[].index The index of the offer.

--- a/packages/mangrove.js/src/kandel/kandelDistributionHelper.ts
+++ b/packages/mangrove.js/src/kandel/kandelDistributionHelper.ts
@@ -160,8 +160,8 @@ class KandelDistributionHelper {
    * @param ratio The ratio used when calculating the price distribution.
    * @param prices The price distribution.
    * @param firstAskIndex The index of the first ask in the distribution.
-   * @param initialAskGives The initial amount of base to give for all asks. Should be at least minimumBasePerOffer from KandelConfiguration for the market. If not provided, then initialBidGives is used as quote for asks, and the base the ask gives is set to according to the price.
-   * @param initialBidGives The initial amount of quote to give for all bids. Should be at least minimumQuotePerOffer from KandelConfiguration for the market. If not provided, then initialAskGives is used as base for bids, and the quote the bid gives is set to according to the price.
+   * @param initialAskGives The initial amount of base to give for all asks. Should be at least minimumBasePerOfferFactor from KandelConfiguration multiplied with the minimum volume for the market. If not provided, then initialBidGives is used as quote for asks, and the base the ask gives is set to according to the price.
+   * @param initialBidGives The initial amount of quote to give for all bids. Should be at least minimumQuotePerOfferFactor from KandelConfiguration multiplied with the minimum volume for the market. If not provided, then initialAskGives is used as base for bids, and the quote the bid gives is set to according to the price.
    * @returns The distribution of bids and asks and their base and quote.
    */
   public calculateDistributionFromPrices(

--- a/packages/mangrove.js/src/kandel/kandelDistributionHelper.ts
+++ b/packages/mangrove.js/src/kandel/kandelDistributionHelper.ts
@@ -127,35 +127,77 @@ class KandelDistributionHelper {
     );
   }
 
+  /** Calculates distribution of bids and asks with constant quote and a matching base given the price distribution.
+   * @param ratio The ratio used when calculating the price distribution.
+   * @param prices The price distribution.
+   * @param constantQuote The constant quote for the distribution.
+   * @param firstAskIndex The index of the first ask in the distribution.
+   * @returns The distribution of bids and asks and their base and quote.
+   */
+  public calculateDistributionConstantQuote(
+    ratio: Big,
+    prices: Big[],
+    constantQuote: Big,
+    firstAskIndex: number
+  ): KandelDistribution {
+    const quote = this.roundQuote(constantQuote);
+    const offers = prices.map((p, index) => ({
+      index,
+      base: this.baseFromQuoteAndPrice(quote, p),
+      quote: quote,
+      offerType: this.getBA(index, firstAskIndex),
+    }));
+    return new KandelDistribution(
+      ratio,
+      offers.length,
+      offers,
+      this.baseDecimals,
+      this.quoteDecimals
+    );
+  }
+
   /** Calculates distribution of bids and asks and their base and quote amounts to match the price distribution.
    * @param ratio The ratio used when calculating the price distribution.
    * @param prices The price distribution.
    * @param firstAskIndex The index of the first ask in the distribution.
-   * @param initialAskGives The initial amount of base to give for all asks.
-   * @param initialBidGives The initial amount of quote to give for all bids. If not provided, then initialAskGives is used as base for bids, and the quote the bid gives is set to according to the price.
+   * @param initialAskGives The initial amount of base to give for all asks. Should be at least minimumBasePerOffer from KandelConfiguration for the market. If not provided, then initialBidGives is used as quote for asks, and the base the ask gives is set to according to the price.
+   * @param initialBidGives The initial amount of quote to give for all bids. Should be at least minimumQuotePerOffer from KandelConfiguration for the market. If not provided, then initialAskGives is used as base for bids, and the quote the bid gives is set to according to the price.
    * @returns The distribution of bids and asks and their base and quote.
    */
   public calculateDistributionFromPrices(
     ratio: Big,
     prices: Big[],
     firstAskIndex: number,
-    initialAskGives: Big,
+    initialAskGives?: Big,
     initialBidGives?: Big
   ) {
-    const distribution = initialBidGives
-      ? this.calculateDistributionConstantGives(
-          ratio,
-          prices,
-          initialAskGives,
-          initialBidGives,
-          firstAskIndex
-        )
-      : this.calculateDistributionConstantBase(
-          ratio,
-          prices,
-          initialAskGives,
-          firstAskIndex
-        );
+    if (!initialBidGives && !initialAskGives)
+      throw Error(
+        "Either initialAskGives or initialBidGives must be provided."
+      );
+
+    const distribution =
+      initialBidGives && initialAskGives
+        ? this.calculateDistributionConstantGives(
+            ratio,
+            prices,
+            initialAskGives,
+            initialBidGives,
+            firstAskIndex
+          )
+        : initialAskGives
+        ? this.calculateDistributionConstantBase(
+            ratio,
+            prices,
+            initialAskGives,
+            firstAskIndex
+          )
+        : this.calculateDistributionConstantQuote(
+            ratio,
+            prices,
+            initialBidGives,
+            firstAskIndex
+          );
     return distribution;
   }
 

--- a/packages/mangrove.js/src/kandel/kandelInstance.ts
+++ b/packages/mangrove.js/src/kandel/kandelInstance.ts
@@ -19,7 +19,7 @@ import KandelConfiguration from "./kandelConfiguration";
 /**
  * @notice Parameters for a Kandel instance.
  * @param gasprice The gas price used when provisioning offers.
- * @param gasreq The gas required to execute a trade. The default gasreq is taken into account for the default minimumBasePerOffer and minimumQuotePerOffer in KandelConfiguration. A higher gasreq will require higher gives per offer to avoid density errors.
+ * @param gasreq The gas required to execute a trade.
  * @param ratio The ratio of the geometric progression of prices.
  * @param compoundRateBase The rate at which the base token is compounded.
  * @param compoundRateQuote The rate at which the quote token is compounded.

--- a/packages/mangrove.js/src/kandel/kandelInstance.ts
+++ b/packages/mangrove.js/src/kandel/kandelInstance.ts
@@ -52,8 +52,6 @@ export type KandelParameterOverrides = {
 
 /** @title Management of a single Kandel instance. */
 class KandelInstance {
-  maxUint256 = ethers.BigNumber.from(2).pow(256).sub(1);
-
   kandel: typechain.GeometricKandel;
   address: string;
   precision: number;
@@ -687,10 +685,10 @@ class KandelInstance {
     return {
       baseAmount: baseAmount
         ? this.market.base.toUnits(baseAmount)
-        : this.maxUint256,
+        : ethers.constants.MaxUint256,
       quoteAmount: quoteAmount
         ? this.market.quote.toUnits(quoteAmount)
-        : this.maxUint256,
+        : ethers.constants.MaxUint256,
     };
   }
 
@@ -729,7 +727,7 @@ class KandelInstance {
       params.recipientAddress ?? (await this.market.mgv.signer.getAddress());
     const freeWei = params.withdrawFunds
       ? UnitCalculations.toUnits(params.withdrawFunds, 18)
-      : this.maxUint256;
+      : ethers.constants.MaxUint256;
 
     const { txs, lastChunk } = await this.retractOfferChunks(
       { retractParams: params, skipLast: true },

--- a/packages/mangrove.js/src/kandelStrategies.ts
+++ b/packages/mangrove.js/src/kandelStrategies.ts
@@ -6,6 +6,7 @@ import Market from "./market";
 import KandelDistributionHelper from "./kandel/kandelDistributionHelper";
 import KandelDistributionGenerator from "./kandel/kandelDistributionGenerator";
 import KandelPriceCalculation from "./kandel/kandelPriceCalculation";
+import KandelConfiguration from "./kandel/kandelConfiguration";
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 namespace KandelStrategies {}
@@ -21,6 +22,9 @@ class KandelStrategies {
   /** The Mangrove to interact with. */
   public mgv: Mangrove;
 
+  /** The recommended configuration values to use for Kandel. */
+  public configuration: KandelConfiguration;
+
   /** Constructor
    * @param mgv The Mangrove to interact with.
    */
@@ -28,6 +32,7 @@ class KandelStrategies {
     this.mgv = mgv;
     this.seeder = new KandelSeeder(mgv);
     this.farm = new KandelFarm(mgv);
+    this.configuration = new KandelConfiguration();
   }
 
   /** Creates a KandelInstance object to interact with a Kandel strategy on Mangrove.

--- a/packages/mangrove.js/src/mangrove.ts
+++ b/packages/mangrove.js/src/mangrove.ts
@@ -667,7 +667,7 @@ class Mangrove {
   ): Promise<Mangrove.OpenMarketInfo[]> {
     // set default params
     params.from ??= 0;
-    params.maxLen ??= ethers.BigNumber.from(2).pow(256).sub(1);
+    params.maxLen ??= ethers.constants.MaxUint256;
     params.configs ??= true;
     params.tokenInfos ??= true;
     // read open markets and their configs off mgvReader

--- a/packages/mangrove.js/src/semibook.ts
+++ b/packages/mangrove.js/src/semibook.ts
@@ -919,6 +919,15 @@ class Semibook implements Iterable<Market.Offer> {
     };
   }
 
+  /** Determines the minimum volume required to stay above density limit for the given gasreq.
+   * @param gasreq The gas requirement for the offer.
+   * @returns The minimum volume required to stay above density limit.
+   */
+  public async getMinimumVolume(gasreq: number) {
+    const config = await this.getConfig();
+    return config.density.mul(gasreq + config.offer_gasbase);
+  }
+
   static rawIdToId(rawId: BigNumber): number | undefined {
     const id = rawId.toNumber();
     return id === 0 ? undefined : id;

--- a/packages/mangrove.js/src/semibook.ts
+++ b/packages/mangrove.js/src/semibook.ts
@@ -309,7 +309,7 @@ class Semibook implements Iterable<Market.Offer> {
       "boundary" in params
         ? params.boundary
         : buying
-        ? Big(2).pow(256).minus(1)
+        ? Big(ethers.constants.MaxUint256.toString())
         : 0;
     const initialWants = Big(buying ? params.given : boundary);
     const initialGives = Big(buying ? boundary : params.given);

--- a/packages/mangrove.js/test/integration/market.integration.test.ts
+++ b/packages/mangrove.js/test/integration/market.integration.test.ts
@@ -11,7 +11,7 @@ import { Mangrove, Market, Semibook } from "../../src";
 import * as helpers from "../util/helpers";
 
 import { Big } from "big.js";
-import { BigNumber, utils } from "ethers";
+import { BigNumber, ethers, utils } from "ethers";
 import * as mockito from "ts-mockito";
 import { Bigish } from "../../src/types";
 import { MgvReader } from "../../src/types/typechain/MgvReader";
@@ -896,7 +896,7 @@ describe("Market integration tests suite", () => {
     const buyPromises = await market.buy({
       offerId: notBest,
       total: 1,
-      price: Big(2).pow(256).minus(1),
+      price: Big(ethers.constants.MaxUint256.toString()),
     });
     const result = await buyPromises.result;
 

--- a/packages/mangrove.js/test/integration/offermaker.integration.test.ts
+++ b/packages/mangrove.js/test/integration/offermaker.integration.test.ts
@@ -1,7 +1,7 @@
 // Integration tests for SimpleMaker.ts
 import { afterEach, beforeEach, describe, it } from "mocha";
 
-import { BigNumber } from "ethers";
+import { BigNumber, ethers } from "ethers";
 
 import assert from "assert";
 import { Mangrove, OfferLogic, LiquidityProvider, OfferMaker } from "../../src";
@@ -104,7 +104,7 @@ describe("OfferMaker", () => {
 
         assert.strictEqual(
           mgv.toUnits(allowanceForLogic, 6).toString(),
-          BigNumber.from(2).pow(256).sub(1).toString(),
+          ethers.constants.MaxUint256.toString(),
           "allowance should be 2^256-1"
         );
       });
@@ -145,7 +145,7 @@ describe("OfferMaker", () => {
 
         assert.strictEqual(
           mgv.toUnits(allowanceForEOA, 6).toString(),
-          BigNumber.from(2).pow(256).sub(1).toString(),
+          ethers.constants.MaxUint256.toString(),
           "allowance should be 2^256-1"
         );
       });

--- a/packages/mangrove.js/test/integration/offermaker.integration.test.ts
+++ b/packages/mangrove.js/test/integration/offermaker.integration.test.ts
@@ -1,10 +1,10 @@
 // Integration tests for SimpleMaker.ts
 import { afterEach, beforeEach, describe, it } from "mocha";
 
-import { BigNumber, ethers } from "ethers";
-
 import assert from "assert";
-import { Mangrove, OfferLogic, LiquidityProvider, OfferMaker } from "../../src";
+import { ethers } from "ethers";
+
+import { Mangrove, LiquidityProvider, OfferMaker } from "../../src";
 import { approxEq } from "../util/helpers";
 
 import { Big } from "big.js";

--- a/packages/mangrove.js/test/unit/kandelConfiguration.unit.test.ts
+++ b/packages/mangrove.js/test/unit/kandelConfiguration.unit.test.ts
@@ -20,28 +20,28 @@ describe(`${KandelConfiguration.prototype.constructor.name} unit tests suite`, (
           markets: {
             TokenA: {
               TokenB: {
-                minimumBasePerOffer: 2,
-                minimumQuotePerOffer: "3",
+                minimumBasePerOfferFactor: 2,
+                minimumQuotePerOfferFactor: "3",
                 ratio: 1.001,
                 aaveEnabled: true,
               },
               FailingConfig0: {
                 aaveEnabled: null,
-                minimumBasePerOffer: 1,
-                minimumQuotePerOffer: 1,
+                minimumBasePerOfferFactor: 1,
+                minimumQuotePerOfferFactor: 1,
                 spread: null,
                 ratio: null,
               },
               FailingConfig1: {},
-              FailingConfig2: { minimumBasePerOffer: 1 },
+              FailingConfig2: { minimumBasePerOfferFactor: 1 },
               FailingConfig3: {
-                minimumBasePerOffer: 1,
-                minimumQuotePerOffer: 1,
+                minimumBasePerOfferFactor: 1,
+                minimumQuotePerOfferFactor: 1,
                 spread: null,
               },
               FailingConfig4: {
-                minimumBasePerOffer: 1,
-                minimumQuotePerOffer: 1,
+                minimumBasePerOfferFactor: 1,
+                minimumQuotePerOfferFactor: 1,
                 ratio: null,
               },
             },
@@ -110,14 +110,14 @@ describe(`${KandelConfiguration.prototype.constructor.name} unit tests suite`, (
       assert.equal(config.aaveEnabled, true);
       assert.equal(config.maxOffersInRetractChunk, 50);
       assert.equal(config.gaspriceFactor, 10);
-      assert.equal(config.minimumBasePerOffer.toNumber(), 2);
-      assert.equal(config.minimumQuotePerOffer.toNumber(), 3);
+      assert.equal(config.minimumBasePerOfferFactor.toNumber(), 2);
+      assert.equal(config.minimumQuotePerOfferFactor.toNumber(), 3);
     });
 
     [
       "aaveEnabled is not configured for pair TokenA/FailingConfig0 on network configTest.",
-      "minimumBasePerOffer is not configured for pair TokenA/FailingConfig1 on network configTest.",
-      "minimumQuotePerOffer is not configured for pair TokenA/FailingConfig2 on network configTest.",
+      "minimumBasePerOfferFactor is not configured for pair TokenA/FailingConfig1 on network configTest.",
+      "minimumQuotePerOfferFactor is not configured for pair TokenA/FailingConfig2 on network configTest.",
       "spread is not configured for pair TokenA/FailingConfig3 on network configTest.",
       "ratio is not configured for pair TokenA/FailingConfig4 on network configTest.",
     ].forEach((message, index) => {
@@ -180,7 +180,7 @@ describe(`${KandelConfiguration.prototype.constructor.name} unit tests suite`, (
         "FailingConfig0"
       );
       assert.equal(config.spread, null);
-      assert.equal(config.minimumBasePerOffer, 1);
+      assert.equal(config.minimumBasePerOfferFactor, 1);
     });
   });
 });

--- a/packages/mangrove.js/test/unit/kandelConfiguration.unit.test.ts
+++ b/packages/mangrove.js/test/unit/kandelConfiguration.unit.test.ts
@@ -1,0 +1,186 @@
+import assert from "assert";
+import { describe, it } from "mocha";
+import KandelConfiguration from "../../src/kandel/kandelConfiguration";
+
+describe(`${KandelConfiguration.prototype.constructor.name} unit tests suite`, () => {
+  let sut: KandelConfiguration;
+  let sutWithOverride: KandelConfiguration;
+  beforeEach(() => {
+    sut = new KandelConfiguration();
+    sutWithOverride = new KandelConfiguration({
+      gaspriceFactor: 10,
+      maxOffersInPopulateChunk: 50,
+      maxOffersInRetractChunk: 50,
+      aaveEnabled: false,
+      spread: 1,
+      ratio: 1.01,
+      networks: {
+        configTest: {
+          spread: 2,
+          markets: {
+            TokenA: {
+              TokenB: {
+                minimumBasePerOffer: 2,
+                minimumQuotePerOffer: "3",
+                ratio: 1.001,
+                aaveEnabled: true,
+              },
+              FailingConfig0: {
+                aaveEnabled: null,
+                minimumBasePerOffer: 1,
+                minimumQuotePerOffer: 1,
+                spread: null,
+                ratio: null,
+              },
+              FailingConfig1: {},
+              FailingConfig2: { minimumBasePerOffer: 1 },
+              FailingConfig3: {
+                minimumBasePerOffer: 1,
+                minimumQuotePerOffer: 1,
+                spread: null,
+              },
+              FailingConfig4: {
+                minimumBasePerOffer: 1,
+                minimumQuotePerOffer: 1,
+                ratio: null,
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+
+  describe(
+    KandelConfiguration.prototype.getConfiguredMarketsForNetwork.name,
+    () => {
+      it(`configTest`, () => {
+        // Act
+        const markets =
+          sutWithOverride.getConfiguredMarketsForNetwork("configTest");
+        // Assert
+        assert.deepStrictEqual(markets, [
+          { base: "TokenA", quote: "TokenB" },
+          { base: "TokenA", quote: "FailingConfig0" },
+          { base: "TokenA", quote: "FailingConfig1" },
+          { base: "TokenA", quote: "FailingConfig2" },
+          { base: "TokenA", quote: "FailingConfig3" },
+          { base: "TokenA", quote: "FailingConfig4" },
+        ]);
+      });
+
+      it(`maticmum`, () => {
+        // Act
+        const markets = sut.getConfiguredMarketsForNetwork("maticmum");
+        // Assert
+        assert.deepStrictEqual(markets, [
+          { base: "WETH", quote: "USDC" },
+          { base: "USDC", quote: "USDT" },
+          { base: "WMATIC", quote: "WETH" },
+        ]);
+      });
+
+      it(`unknown`, () => {
+        // Act
+        const markets = sut.getConfiguredMarketsForNetwork("unknown");
+        // Assert
+        assert.deepStrictEqual(markets, []);
+      });
+    }
+  );
+
+  describe(KandelConfiguration.prototype.getConfigForBaseQuote.name, () => {
+    it("inherits and overrides for market", () => {
+      // Arrange/act
+      const config = sutWithOverride.getConfigForBaseQuote(
+        "configTest",
+        "TokenA",
+        "TokenB"
+      );
+
+      // Assert
+      assert.equal(config.spread, 2, "overriden for network");
+      assert.equal(config.ratio.toNumber(), 1.001, "overridden for market");
+      assert.equal(
+        config.maxOffersInPopulateChunk,
+        50,
+        "inherited from global"
+      );
+      // Assert all others are also read
+      assert.equal(config.aaveEnabled, true);
+      assert.equal(config.maxOffersInRetractChunk, 50);
+      assert.equal(config.gaspriceFactor, 10);
+      assert.equal(config.minimumBasePerOffer.toNumber(), 2);
+      assert.equal(config.minimumQuotePerOffer.toNumber(), 3);
+    });
+
+    [
+      "aaveEnabled is not configured for pair TokenA/FailingConfig0 on network configTest.",
+      "minimumBasePerOffer is not configured for pair TokenA/FailingConfig1 on network configTest.",
+      "minimumQuotePerOffer is not configured for pair TokenA/FailingConfig2 on network configTest.",
+      "spread is not configured for pair TokenA/FailingConfig3 on network configTest.",
+      "ratio is not configured for pair TokenA/FailingConfig4 on network configTest.",
+    ].forEach((message, index) => {
+      it(`throws on missing config ${index} - ${message}`, () => {
+        // Act/Assert
+        assert.throws(
+          () =>
+            sutWithOverride.getConfigForBaseQuote(
+              "configTest",
+              "TokenA",
+              `FailingConfig${index}`
+            ),
+          { message }
+        );
+      });
+    });
+
+    it("parses all expected valid", () => {
+      sut.getNetworks().forEach((network) => {
+        sut.getConfiguredMarketsForNetwork(network).forEach((market) => {
+          // Act/assert - simply do not throw.
+          sut.getConfigForBaseQuote(network, market.base, market.quote);
+        });
+      });
+    });
+  });
+
+  describe(KandelConfiguration.prototype.getMostSpecificConfig.name, () => {
+    it("does not fail on missing network", () => {
+      const config = sutWithOverride.getMostSpecificConfig(
+        "unknown",
+        "unknown",
+        "unknown"
+      );
+      assert.equal(config.spread, 1);
+    });
+
+    it("does not fail on missing base", () => {
+      const config = sutWithOverride.getMostSpecificConfig(
+        "configTest",
+        "unknown",
+        "unknown"
+      );
+      assert.equal(config.spread, 2);
+    });
+
+    it("does not fail on missing quote", () => {
+      const config = sutWithOverride.getMostSpecificConfig(
+        "configTest",
+        "TokenA",
+        "unknown"
+      );
+      assert.equal(config.spread, 2);
+    });
+
+    it("does not fail on missing properties", () => {
+      const config = sutWithOverride.getMostSpecificConfig(
+        "configTest",
+        "TokenA",
+        "FailingConfig0"
+      );
+      assert.equal(config.spread, null);
+      assert.equal(config.minimumBasePerOffer, 1);
+    });
+  });
+});

--- a/packages/mangrove.js/test/unit/kandelDistribution.unit.test.ts
+++ b/packages/mangrove.js/test/unit/kandelDistribution.unit.test.ts
@@ -11,9 +11,9 @@ describe("KandelDistribution unit tests suite", () => {
   describe(
     KandelDistribution.prototype.calculateConstantGivesPerOffer.name,
     () => {
-      it("can calculate constant outbound", () => {
-        // Arrange
-        const sut = new KandelDistribution(
+      let sut: KandelDistribution;
+      beforeEach(() => {
+        sut = new KandelDistribution(
           Big(1),
           5,
           [
@@ -26,7 +26,9 @@ describe("KandelDistribution unit tests suite", () => {
           4,
           6
         );
+      });
 
+      it("can calculate constant outbound", () => {
         // Act
         const { askGives, bidGives } = sut.calculateConstantGivesPerOffer(
           Big(3),
@@ -36,6 +38,15 @@ describe("KandelDistribution unit tests suite", () => {
         // Assert
         assert.equal(askGives.toNumber(), 1);
         assert.equal(bidGives?.toNumber(), 1000);
+      });
+
+      it("can work without any available", () => {
+        // Act
+        const { askGives, bidGives } = sut.calculateConstantGivesPerOffer();
+
+        // Assert
+        assert.equal(askGives, undefined);
+        assert.equal(bidGives, undefined);
       });
     }
   );

--- a/packages/mangrove.js/test/unit/kandelDistributionGenerator.unit.test.ts
+++ b/packages/mangrove.js/test/unit/kandelDistributionGenerator.unit.test.ts
@@ -243,4 +243,87 @@ describe(`${KandelDistributionGenerator.prototype.constructor.name} unit tests s
       });
     }
   );
+
+  describe(
+    KandelDistributionGenerator.prototype.calculateMinimumDistribution.name,
+    () => {
+      const ratio = new Big(2);
+      const minPrice = Big(1000);
+      const pricePoints = 5;
+      const priceParams = { minPrice, ratio, pricePoints };
+      const midPrice = Big(7000);
+      it("throws if both constant", () => {
+        // Act/sddrty
+        assert.throws(
+          () =>
+            sut.calculateMinimumDistribution({
+              constantBase: true,
+              constantQuote: true,
+              minimumBasePerOffer: 1,
+              minimumQuotePerOffer: 1,
+              priceParams,
+              midPrice,
+            }),
+          { message: "Both base and quote cannot be constant" }
+        );
+      });
+      it("can have constant base", () => {
+        // Arrange/Act
+        const distribution = sut.calculateMinimumDistribution({
+          constantBase: true,
+          minimumBasePerOffer: 1,
+          minimumQuotePerOffer: 1000,
+          priceParams,
+          midPrice,
+        });
+
+        // Assert
+        assert.equal(distribution.offers[0].base.toNumber(), 1);
+        assert.equal(
+          1,
+          [...new Set(distribution.offers.map((x) => x.base))].length
+        );
+      });
+
+      it("can have constant quote", () => {
+        // Arrange/Act
+        const distribution = sut.calculateMinimumDistribution({
+          constantQuote: true,
+          minimumBasePerOffer: 1,
+          minimumQuotePerOffer: 1000,
+          priceParams,
+          midPrice,
+        });
+
+        // Assert
+        assert.equal(distribution.offers[0].quote.toNumber(), 16000);
+        assert.equal(
+          1,
+          [...new Set(distribution.offers.map((x) => x.quote))].length
+        );
+      });
+
+      it("can have constant gives", () => {
+        // Arrange/Act
+        const distribution = sut.calculateMinimumDistribution({
+          minimumBasePerOffer: 1,
+          minimumQuotePerOffer: 1000,
+          priceParams,
+          midPrice,
+        });
+
+        // Assert there should only be exactly two different gives - one for ask and one for bids.
+        assert.equal(
+          2,
+          [
+            ...new Set(
+              distribution.offers.map((x) =>
+                x.offerType == "bids" ? x.quote : x.base
+              )
+            ),
+          ].length
+        );
+      });
+    }
+  );
 });

--- a/packages/mangrove.js/test/unit/kandelDistributionHelper.unit.test.ts
+++ b/packages/mangrove.js/test/unit/kandelDistributionHelper.unit.test.ts
@@ -227,6 +227,59 @@ describe("KandelDistributionHelper unit tests suite", () => {
           );
         });
       });
+    });
+  });
+
+  describe(
+    KandelDistributionHelper.prototype.calculateInitialGives.name,
+    () => {
+      it("returns minimum on empty list", () => {
+        // Arrange
+        const sut = new KandelDistributionHelper(0, 0);
+
+        // Act
+        const { askGives, bidGives } = sut.calculateInitialGives(
+          [],
+          Big(1),
+          Big(2)
+        );
+
+        // Assert
+        assert.equal(askGives.toNumber(), 1);
+        assert.equal(bidGives.toNumber(), 2);
+      });
+
+      it("returns minimum if no prices affect it", () => {
+        // Arrange
+        const sut = new KandelDistributionHelper(0, 0);
+
+        // Act
+        const { askGives, bidGives } = sut.calculateInitialGives(
+          [Big(1000)],
+          Big(0.1),
+          Big(100)
+        );
+
+        // Assert
+        assert.equal(askGives.toNumber(), 0.1);
+        assert.equal(bidGives.toNumber(), 100);
+      });
+
+      it("returns higher than minimum if dual at some price would be below its minimum", () => {
+        // Arrange
+        const sut = new KandelDistributionHelper(0, 0);
+
+        // Act
+        const { askGives, bidGives } = sut.calculateInitialGives(
+          [Big(2000), Big(1000), Big(500), Big(4000)],
+          Big(1),
+          Big(1000)
+        );
+
+        // Assert
+        assert.equal(askGives.toNumber(), 2);
+        assert.equal(bidGives.toNumber(), 4000);
+      });
     }
   );
 

--- a/packages/mangrove.js/test/unit/kandelDistributionHelper.unit.test.ts
+++ b/packages/mangrove.js/test/unit/kandelDistributionHelper.unit.test.ts
@@ -135,17 +135,22 @@ describe("KandelDistributionHelper unit tests suite", () => {
     }
   );
 
-  describe(
+  [
     KandelDistributionHelper.prototype.calculateDistributionConstantBase.name,
-    () => {
-      it("can calculate distribution with fixed base volume which follows geometric distribution", () => {
+    KandelDistributionHelper.prototype.calculateDistributionConstantQuote.name,
+  ].forEach((methodName) => {
+    const ratio = new Big(1.08);
+    const firstBase = Big(2);
+    const firstQuote = Big(3000);
+    const pricePoints = 10;
+    const firstAskIndex = 5;
+    const constantBase =
+      methodName ===
+      KandelDistributionHelper.prototype.calculateDistributionConstantBase.name;
+    describe(methodName, () => {
+      it(`can calculate distribution with fixed base/quote constantBase=${constantBase} volume which follows geometric distribution`, () => {
         // Arrange
-        const ratio = new Big(1.08);
-        const firstBase = Big(2);
-        const firstQuote = Big(3000);
-        const pricePoints = 10;
         const sut = new KandelDistributionHelper(12, 12);
-        const firstAskIndex = 5;
         const pricesAndRatio = new KandelPriceCalculation().calculatePrices({
           minPrice: firstQuote.div(firstBase),
           ratio,
@@ -153,31 +158,39 @@ describe("KandelDistributionHelper unit tests suite", () => {
         });
 
         // Act
-        const distribution = sut.calculateDistributionConstantBase(
-          pricesAndRatio.ratio,
-          pricesAndRatio.prices,
-          firstBase,
-          firstAskIndex
-        );
+        const distribution = constantBase
+          ? sut.calculateDistributionConstantBase(
+              pricesAndRatio.ratio,
+              pricesAndRatio.prices,
+              firstBase,
+              firstAskIndex
+            )
+          : sut.calculateDistributionConstantQuote(
+              pricesAndRatio.ratio,
+              pricesAndRatio.prices,
+              firstQuote,
+              firstAskIndex
+            );
 
         // Assert
         let price = firstQuote.div(firstBase);
         distribution.offers.forEach((e, i) => {
           assert.equal(e.offerType, i < firstAskIndex ? "bids" : "asks");
           assert.equal(
-            e.quote.div(e.base).toNumber(),
-            price.toNumber(),
+            e.quote.div(e.base).toPrecision(6),
+            price.toPrecision(6),
             `Price is not as expected at ${i}`
           );
+          if (constantBase) {
+            assert.equal(firstBase.toNumber(), e.base.toNumber());
+          } else {
+            assert.equal(firstQuote.toNumber(), e.quote.toNumber());
+          }
           price = price.mul(ratio);
         });
       });
-      it("rounds off base and gives according to decimals", () => {
+      it(`rounds off base and gives according to decimals for fixed base/quote constantBase=${constantBase}`, () => {
         // Arrange
-        const ratio = new Big(1.08);
-        const firstBase = Big(2);
-        const firstQuote = Big(3000);
-        const pricePoints = 10;
         const sut = new KandelDistributionHelper(4, 6);
         const pricesAndRatio = new KandelPriceCalculation().calculatePrices({
           minPrice: firstQuote.div(firstBase),
@@ -186,12 +199,19 @@ describe("KandelDistributionHelper unit tests suite", () => {
         });
 
         // Act
-        const distribution = sut.calculateDistributionConstantBase(
-          pricesAndRatio.ratio,
-          pricesAndRatio.prices,
-          firstBase,
-          5
-        );
+        const distribution = constantBase
+          ? sut.calculateDistributionConstantBase(
+              pricesAndRatio.ratio,
+              pricesAndRatio.prices,
+              firstBase,
+              firstAskIndex
+            )
+          : sut.calculateDistributionConstantQuote(
+              pricesAndRatio.ratio,
+              pricesAndRatio.prices,
+              firstQuote,
+              firstAskIndex
+            );
 
         // Assert
         distribution.offers.forEach((e) => {


### PR DESCRIPTION
See the title for each commit:
1) use maxuint256 constant from ethers instead of calculating it our selves.
2) add kandelConfiguration - with some initial configuration, better values needed.
3) enable the ability to have constant quote for a distribution like we had constant base
4) enable calculation of a minimum distribution based on the minimum per offer

Note: (4) is a minimum distribution given that we have constant base, constant quote, or constant outgoing. If we allowed varying volume per offer then a smaller total volume could be allowed.