### PR TITLE
fix(esbuild): fix resolving commonlib from multiple paths

### DIFF
--- a/packages/mangrove.js/esbuild.mjs
+++ b/packages/mangrove.js/esbuild.mjs
@@ -2,7 +2,35 @@
 const BrowserBuildPath = "./dist/browser/mangrove.min.js";
 
 import { build } from "esbuild";
-import resolve from "esbuild-plugin-resolve";
+import path from "node:path";
+import { fileURLToPath } from "url";
+
+const currentFilePath = fileURLToPath(import.meta.url);
+
+function getPath(absoluteResolvePath, shim) {
+  const relativePath = path.relative(
+    absoluteResolvePath,
+    path.dirname(currentFilePath)
+  );
+  return path.join(absoluteResolvePath, relativePath, shim);
+}
+
+const shimOnResolvePlugin = {
+  name: "shimOnResolvePlugin",
+  setup(build) {
+    build.onResolve({ filter: /^@mangrovedao\/commonlib.js$/ }, (args) => {
+      return { path: getPath(args.resolveDir, "shims/commonlib.ts") };
+    });
+
+    build.onResolve({ filter: /^\.\/util\/readJsonWallet$/ }, (args) => {
+      return { path: getPath(args.resolveDir, "shims/readJsonWallet.ts") };
+    });
+
+    build.onResolve({ filter: /^\.\/util\/test\/TestMaker$/ }, (args) => {
+      return { path: getPath(args.resolveDir, "shims/TestMaker.ts") };
+    });
+  },
+};
 
 build({
   entryPoints: ["./src/index.ts"],
@@ -15,11 +43,5 @@ build({
   footer: {
     js: "module.exports = Mangrove;",
   },
-  plugins: [
-    resolve({
-      "@mangrovedao/commonlib.js": "../../shims/commonlib.ts",
-      "./util/readJsonWallet": "../shims/readJsonWallet.ts",
-      "./util/test/TestMaker": "../shims/TestMaker.ts",
-    }),
-  ],
+  plugins: [shimOnResolvePlugin],
 });

--- a/packages/mangrove.js/esbuild.mjs
+++ b/packages/mangrove.js/esbuild.mjs
@@ -25,10 +25,6 @@ const shimOnResolvePlugin = {
     build.onResolve({ filter: /^\.\/util\/readJsonWallet$/ }, (args) => {
       return { path: getPath(args.resolveDir, "shims/readJsonWallet.ts") };
     });
-
-    build.onResolve({ filter: /^\.\/util\/test\/TestMaker$/ }, (args) => {
-      return { path: getPath(args.resolveDir, "shims/TestMaker.ts") };
-    });
   },
 };
 

--- a/packages/mangrove.js/package.json
+++ b/packages/mangrove.js/package.json
@@ -67,7 +67,6 @@
     "@mangrovedao/reliable-event-subscriber": "1.0.6",
     "async-mutex": "^0.4.0",
     "big.js": "^6.2.1",
-    "esbuild-plugin-resolve": "^1.0.3",
     "ethers": "^5.7.2",
     "just-clone": "^6.2.0",
     "node-cleanup": "^2.1.2",

--- a/packages/mangrove.js/shims/TestMaker.ts
+++ b/packages/mangrove.js/shims/TestMaker.ts
@@ -1,7 +1,0 @@
-class TestMaker {
-  constructor() {
-    throw new Error("This is a shim, cannot be used");
-  }
-}
-
-export default TestMaker;

--- a/packages/mangrove.js/src/index.ts
+++ b/packages/mangrove.js/src/index.ts
@@ -23,7 +23,6 @@ import KandelFarm from "./kandel/kandelFarm";
 import KandelSeeder from "./kandel/kandelSeeder";
 import KandelInstance from "./kandel/kandelInstance";
 import OfferMaker from "./offerMaker";
-import TestMaker from "./util/test/TestMaker";
 
 // Turn off Ethers.js warnings
 // ethers.utils.Logger.setLogLevel(ethers.utils.Logger.levels.ERROR);

--- a/packages/mangrove.js/src/index.ts
+++ b/packages/mangrove.js/src/index.ts
@@ -23,6 +23,7 @@ import KandelFarm from "./kandel/kandelFarm";
 import KandelSeeder from "./kandel/kandelSeeder";
 import KandelInstance from "./kandel/kandelInstance";
 import OfferMaker from "./offerMaker";
+import TestMaker from "./util/test/TestMaker";
 
 // Turn off Ethers.js warnings
 // ethers.utils.Logger.setLogLevel(ethers.utils.Logger.levels.ERROR);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1539,7 +1539,6 @@ __metadata:
     cross-env: ^7.0.3
     dir-compare: ^4.0.0
     esbuild: ^0.16.16
-    esbuild-plugin-resolve: ^1.0.3
     eslint: ^8.31.0
     eslint-config-prettier: ^8.8.0
     ethers: ^5.7.2
@@ -3343,13 +3342,6 @@ __metadata:
     d: ^1.0.1
     ext: ^1.1.2
   checksum: cd49722c2a70f011eb02143ef1c8c70658d2660dead6641e160b94619f408b9cf66425515787ffe338affdf0285ad54f4eae30ea5bd510e33f8659ec53bcaa70
-  languageName: node
-  linkType: hard
-
-"esbuild-plugin-resolve@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "esbuild-plugin-resolve@npm:1.0.3"
-  checksum: 0f2f7b666a40ad6029fd6056c110cfb038a2dea308cd42be24730ba86d8e518fdc3550b7fc6c4444c228c734db556920654862d5f295fda6a258824fb5e7ea47
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
commonlib got resolved from multiple paths, and with the esbuild resolve plugin this only worked if the right import was hit first. That gave sporadic esbuild errors. This change uses absolute paths for the imports. Also removed testMaker shim as it was unused.