### PR TITLE
feat(bot-utils): Change from default provider to StaticJsonRpcProvider

### DIFF
--- a/packages/bot-utils/src/setup.ts
+++ b/packages/bot-utils/src/setup.ts
@@ -4,7 +4,7 @@ import { IConfig } from "config";
 import http from "http";
 import { ToadScheduler } from "toad-scheduler";
 import * as log from "./util/logger";
-import { getDefaultProvider } from "@ethersproject/providers";
+import { StaticJsonRpcProvider } from "@ethersproject/providers";
 import { BaseProvider } from "@ethersproject/providers";
 import { Wallet } from "@ethersproject/wallet";
 import { NonceManager } from "@ethersproject/experimental";
@@ -97,7 +97,7 @@ export class Setup {
     }
 
     const providerUrl = process.env["RPC_NODE_URL"];
-    const provider = getDefaultProvider(providerUrl);
+    const provider = new StaticJsonRpcProvider(providerUrl);
     const signer = new Wallet(process.env["PRIVATE_KEY"], provider);
     const nonceManager = new NonceManager(signer);
     const mgv = await Mangrove.connect({


### PR DESCRIPTION
As per the doc https://docs.ethers.org/v5/api/providers/jsonrpc-provider/
> [...] there are also many times where it is known the network cannot change, such as when connecting to an INFURA endpoint, in which case, the StaticJsonRpcProvider can be used which will indefinitely cache the chain ID, which can reduce network traffic and reduce round-trip queries for the chain ID.