### PR TITLE
Feat/fix approve

### DIFF
--- a/packages/mangrove.js/CHANGELOG.md
+++ b/packages/mangrove.js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Next version
 
+- OfferLogic has an `approve` function to ask the underlying logic to approve signer (or an arbitrary address) to spend a specific token on its behalf.
+- Liquidity provider no longer provides `approveAsk`, `approveBids` which were making too much asumptions on router usage.
+- Adapts tutorial scripts accordingly.
+
 # 1.2.4-13 (may 2023)
 
 - Update reliable-event-subscriber to fix rpc bug with go-ethereum

--- a/packages/mangrove.js/CHANGELOG.md
+++ b/packages/mangrove.js/CHANGELOG.md
@@ -3,6 +3,7 @@
 - OfferLogic has an `approve` function to ask the underlying logic to approve signer (or an arbitrary address) to spend a specific token on its behalf.
 - Liquidity provider no longer provides `approveAsk`, `approveBids` which were making too much asumptions on router usage.
 - Adapts tutorial scripts accordingly.
+- bugfix: token approval could not be set to 0
 
 # 1.2.4-13 (may 2023)
 

--- a/packages/mangrove.js/examples/getting-liquidity-provider.js
+++ b/packages/mangrove.js/examples/getting-liquidity-provider.js
@@ -27,7 +27,7 @@ mgv.setAddress("myOffer", "0x<address>");
 const logic = mgv.offerLogic("myOffer");
 const maker = await logic.liquidityProvider(market);
 
-const tx = await maker.approveAsks();
+const tx = await logic.approve(market.base.name, { optAmount: 5000 });
 await tx.wait();
 
 await maker.newAsk(

--- a/packages/mangrove.js/examples/how-tos/reuse-offer.js
+++ b/packages/mangrove.js/examples/how-tos/reuse-offer.js
@@ -36,7 +36,7 @@ await market.quote.contract.mint(
 // comment this in, if you do not have a "dead" offer
 /*
 let directLP = await mgv.liquidityProvider(market);
-let tx = await directLP.approveAsks();
+let tx = await market.base.approveMangrove();
 await tx.wait();
 let provision = await directLP.computeAskProvision();
 let { id: offerId } = await directLP.newAsk({

--- a/packages/mangrove.js/examples/tutorials/on-the-fly-offer.js
+++ b/packages/mangrove.js/examples/tutorials/on-the-fly-offer.js
@@ -21,9 +21,9 @@ market.consoleBids();
 // Create a simple liquidity provider on `market`, using `wallet` as a source of liquidity
 const directLP = await mgv.liquidityProvider(market);
 
-// Liquidity provider needs to approve Mangrove for transfer of base token (DAI) which
+// In order to post an ask, signer needs to approve Mangrove for transfer of base token (DAI) which
 // will be transferred from the wallet to Mangrove and then to the taker when the offer is taken.
-const tx = await directLP.approveAsks();
+const tx = await market.base.approve(mgv.address, { amount: 100.4 });
 await tx.wait();
 
 // Query mangrove to know the bounty for posting a new Ask on `market`

--- a/packages/mangrove.js/src/liquidityProvider.ts
+++ b/packages/mangrove.js/src/liquidityProvider.ts
@@ -16,7 +16,6 @@ for more on big.js vs decimals.js vs. bignumber.js (which is *not* ethers's BigN
 import Big from "big.js";
 import { OfferLogic } from ".";
 import PrettyPrint, { prettyPrintFilter } from "./util/prettyPrint";
-import { ApproveArgs } from "./mgvtoken";
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 namespace LiquidityProvider {
@@ -131,6 +130,40 @@ class LiquidityProvider {
     opts: { id?: number; gasreq?: number; gasprice?: number } = {}
   ): Promise<Big> {
     return this.getMissingProvision("asks", opts);
+  }
+
+  async getMissingProvision(
+    ba: Market.BA,
+    opts: { id?: number; gasreq?: number; gasprice?: number } = {}
+  ): Promise<Big> {
+    const gasreq = opts && opts.gasreq != undefined ? opts.gasreq : this.gasreq;
+    const gasprice = opts && opts.gasprice != undefined ? opts.gasprice : 0;
+    // this computes the total provision required for a new offer on the market
+    const provision = await this.market.getOfferProvision(ba, gasreq, gasprice);
+    let lockedProvision = Big(0);
+    // checking now the funds that are either locked in the offer or on the maker balance on Mangrove
+    if (opts.id) {
+      const { outbound_tkn, inbound_tkn } = this.market.getOutboundInbound(ba);
+      lockedProvision = this.mgv.fromUnits(
+        this.logic
+          ? await this.logic.contract.provisionOf(
+              outbound_tkn.address,
+              inbound_tkn.address,
+              opts.id
+            )
+          : 0,
+        18
+      );
+    }
+    logger.debug(`Get missing provision`, {
+      contextInfo: "mangrove.maker",
+      data: { ba: ba, opts: opts },
+    });
+    if (provision.gt(lockedProvision)) {
+      return provision.sub(lockedProvision);
+    } else {
+      return Big(0);
+    }
   }
 
   /** Given a price, find the id of the immediately-better offer in the
@@ -480,59 +513,6 @@ class LiquidityProvider {
       txPromise,
       (cbArg) => cbArg.type === "OfferRetract"
     );
-  }
-
-  #approveToken(
-    tokenName: string,
-    arg: ApproveArgs = {}
-  ): Promise<ethers.ContractTransaction> {
-    if (this.logic) {
-      return this.logic.approveToken(tokenName, arg);
-    } else {
-      // LP is an EOA
-      return this.mgv.approveMangrove(tokenName, arg);
-    }
-  }
-
-  approveAsks(arg: ApproveArgs = {}): Promise<ethers.ContractTransaction> {
-    return this.#approveToken(this.market.base.name, arg);
-  }
-  approveBids(arg: ApproveArgs = {}): Promise<ethers.ContractTransaction> {
-    return this.#approveToken(this.market.quote.name, arg);
-  }
-
-  async getMissingProvision(
-    ba: Market.BA,
-    opts: { id?: number; gasreq?: number; gasprice?: number } = {}
-  ): Promise<Big> {
-    const gasreq = opts.gasreq ? opts.gasreq : this.gasreq;
-    const gasprice = opts.gasprice ? opts.gasprice : 0;
-    // this computes the total provision required for a new offer on the market
-    const provision = await this.market.getOfferProvision(ba, gasreq, gasprice);
-    let lockedProvision = Big(0);
-    // checking now the funds that are either locked in the offer or on the maker balance on Mangrove
-    if (opts.id) {
-      const { outbound_tkn, inbound_tkn } = this.market.getOutboundInbound(ba);
-      lockedProvision = this.mgv.fromUnits(
-        this.logic
-          ? await this.logic.contract.provisionOf(
-              outbound_tkn.address,
-              inbound_tkn.address,
-              opts.id
-            )
-          : 0,
-        18
-      );
-    }
-    logger.debug(`Get missing provision`, {
-      contextInfo: "mangrove.maker",
-      data: { ba: ba, opts: opts },
-    });
-    if (provision.gt(lockedProvision)) {
-      return provision.sub(lockedProvision);
-    } else {
-      return Big(0);
-    }
   }
 }
 

--- a/packages/mangrove.js/src/mgvtoken.ts
+++ b/packages/mangrove.js/src/mgvtoken.ts
@@ -27,7 +27,7 @@ function convertToApproveArgs(arg: ApproveArgs): {
 } {
   let amount: Bigish;
   let overrides: ethers.Overrides;
-  if (arg["amount"]) {
+  if (arg["amount"] != undefined) {
     amount = arg["amount"];
   } else if (typeof arg != "object") {
     amount = arg;
@@ -40,9 +40,9 @@ function convertToApproveArgs(arg: ApproveArgs): {
     overrides = arg as ethers.Overrides;
   }
 
-  if (amount && overrides) {
+  if (amount != undefined && overrides) {
     return { amount, overrides };
-  } else if (amount) {
+  } else if (amount != undefined) {
     return { amount, overrides: {} };
   } else if (overrides) {
     return { overrides: overrides };
@@ -203,7 +203,9 @@ class MgvToken {
   }
 
   private getRawApproveAmount(amount?: Bigish): ethers.BigNumber {
-    return amount ? this.toUnits(amount) : ethers.constants.MaxUint256;
+    return amount != undefined
+      ? this.toUnits(amount)
+      : ethers.constants.MaxUint256;
   }
 
   /** Sets the allowance for the spender if it is not already enough.

--- a/packages/mangrove.js/src/offerLogic.ts
+++ b/packages/mangrove.js/src/offerLogic.ts
@@ -68,7 +68,7 @@ class OfferLogic {
       args && args.optSpender != undefined
         ? args.optSpender
         : await this.mgv.signer.getAddress();
-    return await this.contract.approve(
+    return this.contract.approve(
       token.address,
       spender,
       amount,
@@ -134,8 +134,8 @@ class OfferLogic {
   }
 
   /** Retrieves the provision available on Mangrove for the offer logic, in ethers */
-  public async getMangroveBalance() {
-    return await this.mgv.balanceOf(this.address);
+  public getMangroveBalance() {
+    return this.mgv.balanceOf(this.address);
   }
 
   /** Adds ethers for provisioning offers on Mangrove for the offer logic.
@@ -143,8 +143,8 @@ class OfferLogic {
    * @param overrides The ethers overrides to use when calling the fund function.
    * @returns The transaction used to fund the offer logic.
    */
-  public async fundOnMangrove(funds: Bigish, overrides: ethers.Overrides = {}) {
-    return await this.mgv.fundMangrove(funds, this.address, overrides);
+  public fundOnMangrove(funds: Bigish, overrides: ethers.Overrides = {}) {
+    return this.mgv.fundMangrove(funds, this.address, overrides);
   }
 
   /** Withdraw from the OfferLogic's ether balance on Mangrove to the sender's account */

--- a/packages/mangrove.js/src/offerLogic.ts
+++ b/packages/mangrove.js/src/offerLogic.ts
@@ -4,15 +4,6 @@ import { typechain } from "./types";
 
 import { Mangrove } from ".";
 import { TransactionResponse } from "@ethersproject/abstract-provider";
-import { ApproveArgs } from "./mgvtoken";
-
-/* Note on big.js:
-ethers.js's BigNumber (actually BN.js) only handles integers
-big.js handles arbitrary precision decimals, which is what we want
-for more on big.js vs decimals.js vs. bignumber.js (which is *not* ethers's BigNumber):
-  github.com/MikeMcl/big.js/issues/45#issuecomment-104211175
-*/
-import Big from "big.js";
 
 type SignerOrProvider = ethers.ethers.Signer | ethers.ethers.providers.Provider;
 /**
@@ -56,40 +47,33 @@ class OfferLogic {
   }
 
   /**
-   * @note Approves the logic to spend `token`s on signer's behalf.
+   * @note logic approves signer or `args.optSpender` to spend a certain token on its behalf
    * This has to be done for each token the signer's wishes to ask or bid for.
-   * @param arg optional `arg.amount` can be used if one wishes to approve a finite amount
+   * @param args optional `arg.amount` can be used if one wishes to approve a finite amount
    */
-  async approveToken(
+  async approve(
     tokenName: string,
-    arg: ApproveArgs = {}
+    args?: {
+      optSpender?: string;
+      optAmount?: Bigish;
+      optOverrides?: ethers.Overrides;
+    }
   ): Promise<ethers.ContractTransaction> {
-    const router: typechain.AbstractRouter | undefined = await this.router();
     const token = this.mgv.token(tokenName);
-    if (router) {
-      // LP's logic is using a router to manage its liquidity
-      return token.approve(router.address, arg);
-    } else {
-      // LP's logic is doing the routing itself
-      return token.approve(this.address, arg);
-    }
-  }
-
-  /**@note returns logic's allowance to trade `tokenName` on signer's behalf */
-  async allowance(tokenName: string): Promise<Big> {
-    const router: typechain.AbstractRouter | undefined = await this.router();
-    const token = this.mgv.token(tokenName);
-    if (router) {
-      return token.allowance({
-        owner: await this.mgv.signer.getAddress(),
-        spender: router.address,
-      });
-    } else {
-      return token.allowance({
-        owner: await this.mgv.signer.getAddress(),
-        spender: this.address,
-      });
-    }
+    const amount =
+      args && args.optAmount != undefined
+        ? token.toUnits(args.optAmount)
+        : ethers.constants.MaxUint256;
+    const spender =
+      args && args.optSpender != undefined
+        ? args.optSpender
+        : await this.mgv.signer.getAddress();
+    return await this.contract.approve(
+      token.address,
+      spender,
+      amount,
+      args && args.optOverrides ? args.optOverrides : {}
+    );
   }
 
   /** Returns a new `OfferLogic` object with a different signer or provider connected to its ethers.js `contract`

--- a/packages/mangrove.js/test/integration/mgvtoken.integration.test.ts
+++ b/packages/mangrove.js/test/integration/mgvtoken.integration.test.ts
@@ -53,6 +53,14 @@ describe("MGV Token integration tests suite", () => {
     );
   });
 
+  it("approve can be set to 0", async function () {
+    const usdc = mgv.token("USDC");
+    await waitForTransaction(await usdc.approve(mgv.address, 100));
+    await waitForTransaction(await usdc.approve(mgv.address, 0));
+    const allowance = await usdc.allowance();
+    assert.equal(allowance.toNumber(), 0, "allowance should be 0");
+  });
+
   it("approveIfHigher sets when higher but not when lower", async function () {
     const usdc = mgv.token("USDC");
 

--- a/packages/mangrove.js/test/integration/offermaker.integration.test.ts
+++ b/packages/mangrove.js/test/integration/offermaker.integration.test.ts
@@ -84,8 +84,9 @@ describe("OfferMaker", () => {
 
     describe("Before setup", () => {
       it("checks allowance for onchain logic", async () => {
+        const logic = onchain_lp.logic as OfferLogic;
         let allowanceForLogic /*:Big*/ = await mgv.token("TokenB").allowance({
-          owner: onchain_lp.logic.address,
+          owner: logic.address,
           spender: mgv.address,
         });
 
@@ -96,9 +97,9 @@ describe("OfferMaker", () => {
         );
 
         // test default approve amount
-        await w(onchain_lp.logic?.activate(["TokenB"]));
+        await w(logic.activate(["TokenB"]));
         allowanceForLogic /*:Big*/ = await mgv.token("TokenB").allowance({
-          owner: onchain_lp.logic.address,
+          owner: logic.address,
           spender: mgv.address,
         });
 
@@ -151,21 +152,23 @@ describe("OfferMaker", () => {
       });
 
       it("checks provision for EOA provider", async () => {
-        let balance = await mgv.balanceOf(eoa_lp.eoa);
+        const eoa = eoa_lp.eoa as string;
+        let balance = await mgv.balanceOf(eoa);
         assert.strictEqual(balance.toNumber(), 0, "balance should be 0");
 
-        await w(mgv.fundMangrove(2, eoa_lp.eoa));
+        await w(mgv.fundMangrove(2, eoa));
 
-        balance = await mgv.balanceOf(eoa_lp.eoa);
+        balance = await mgv.balanceOf(eoa);
         assert.strictEqual(balance.toNumber(), 2, "balance should be 2");
       });
 
       it("checks provision for onchain logic", async () => {
-        let balance = await mgv.balanceOf(onchain_lp.logic.address);
+        const logic = onchain_lp.logic as OfferLogic;
+        let balance = await mgv.balanceOf(logic.address);
         assert.strictEqual(balance.toNumber(), 0, "balance should be 0");
-        await w(mgv.fundMangrove(2, onchain_lp.logic.address));
+        await w(mgv.fundMangrove(2, logic.address));
 
-        balance = await mgv.balanceOf(onchain_lp.logic.address);
+        balance = await mgv.balanceOf(logic.address);
         assert.strictEqual(balance.toNumber(), 2, "balance should be 2");
       });
     });
@@ -177,12 +180,13 @@ describe("OfferMaker", () => {
       });
 
       it("withdraws", async () => {
+        const logic = onchain_lp.logic as OfferLogic;
         const getBal = async () =>
           mgv.provider.getBalance(await mgv.signer.getAddress());
-        let tx = await mgv.fundMangrove(10, onchain_lp.logic.address);
+        let tx = await mgv.fundMangrove(10, logic.address);
         await tx.wait();
         const oldBal = await getBal();
-        tx = await onchain_lp.logic.withdrawFromMangrove(10);
+        tx = await logic.withdrawFromMangrove(10);
         const receipt = await tx.wait();
         const txcost = receipt.effectiveGasPrice.mul(receipt.gasUsed);
         const diff = mgv.fromUnits(

--- a/packages/mangrove.js/test/integration/offermaker.integration.test.ts
+++ b/packages/mangrove.js/test/integration/offermaker.integration.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, it } from "mocha";
 import assert from "assert";
 import { ethers } from "ethers";
 
-import { Mangrove, LiquidityProvider, OfferMaker } from "../../src";
+import { Mangrove, LiquidityProvider, OfferMaker, OfferLogic } from "../../src";
 import { approxEq } from "../util/helpers";
 
 import { Big } from "big.js";
@@ -355,6 +355,19 @@ describe("OfferMaker", () => {
           updatePromise,
           "Updating on a closed market should fail."
         );
+      });
+
+      it("approves signer for base transfer", async () => {
+        const base = onchain_lp.market.base;
+        const logic = onchain_lp.logic as OfferLogic;
+
+        const tx = await logic.approve(base.name, { optAmount: 42 });
+        const resp = await tx.wait();
+        let allowance = await base.allowance({
+          owner: logic.address,
+          spender: await logic.mgv.signer.getAddress(),
+        });
+        assert.equal(allowance, 42, "Invalid allowance");
       });
     });
   });

--- a/packages/mangrove.js/test/integration/offermaker.integration.test.ts
+++ b/packages/mangrove.js/test/integration/offermaker.integration.test.ts
@@ -364,12 +364,17 @@ describe("OfferMaker", () => {
       it("approves signer for base transfer", async () => {
         const base = onchain_lp.market.base;
         const logic = onchain_lp.logic as OfferLogic;
+        const signer_address = await logic.mgv.signer.getAddress();
 
-        const tx = await logic.approve(base.name, { optAmount: 42 });
-        const resp = await tx.wait();
+        const tx = await logic.approve(base.name, {
+          optAmount: 42,
+          optOverrides: { gasLimit: 80000 },
+        });
+        await tx.wait();
+
         let allowance = await base.allowance({
           owner: logic.address,
-          spender: await logic.mgv.signer.getAddress(),
+          spender: signer_address,
         });
         assert.equal(allowance, 42, "Invalid allowance");
       });


### PR DESCRIPTION
This PR does the following (and replaces #1238 )

- OfferLogic has an `approve` function to ask the underlying logic to approve signer (or an arbitrary address) to spend a specific token on its behalf.
- Liquidity provider no longer provides `approveAsk`, `approveBids` which were making too much asumptions on router usage.
- Adapts tutorial scripts accordingly.
- bugfix: token approval could not be set to 0