### PR TITLE
Revert "build(deps): Bump toad-scheduler from 1.6.1 to 2.2.0"

### DIFF
--- a/packages/bot-arbitrage/package.json
+++ b/packages/bot-arbitrage/package.json
@@ -50,7 +50,7 @@
     "finalhandler": "^1.2.0",
     "nyc": "^15.1.0",
     "serve-static": "^1.15.0",
-    "toad-scheduler": "^2.2.0"
+    "toad-scheduler": "^1.6.1"
   },
   "devDependencies": {
     "@espendk/json-file-reporter": "^1.4.2",

--- a/packages/bot-cleaning/package.json
+++ b/packages/bot-cleaning/package.json
@@ -46,7 +46,7 @@
     "finalhandler": "^1.2.0",
     "nyc": "^15.1.0",
     "serve-static": "^1.15.0",
-    "toad-scheduler": "^2.2.0"
+    "toad-scheduler": "^1.6.1"
   },
   "devDependencies": {
     "@espendk/json-file-reporter": "^1.4.2",

--- a/packages/bot-taker-greedy/package.json
+++ b/packages/bot-taker-greedy/package.json
@@ -47,7 +47,7 @@
     "nyc": "^15.1.0",
     "random": "^3.0.6",
     "serve-static": "^1.15.0",
-    "toad-scheduler": "^2.2.0"
+    "toad-scheduler": "^1.6.1"
   },
   "devDependencies": {
     "@espendk/json-file-reporter": "^1.4.2",

--- a/packages/bot-updategas/package.json
+++ b/packages/bot-updategas/package.json
@@ -48,7 +48,7 @@
     "finalhandler": "^1.2.0",
     "nyc": "^15.1.0",
     "serve-static": "^1.15.0",
-    "toad-scheduler": "^2.2.0"
+    "toad-scheduler": "^1.6.1"
   },
   "devDependencies": {
     "@espendk/json-file-reporter": "^1.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1166,7 +1166,7 @@ __metadata:
     rimraf: ^3.0.2
     serve-static: ^1.15.0
     shelljs: ^0.8.5
-    toad-scheduler: ^2.2.0
+    toad-scheduler: ^1.6.1
     ts-node: ^10.9.1
     typescript: ^4.7.0
   languageName: unknown
@@ -1215,7 +1215,7 @@ __metadata:
     rimraf: ^3.0.2
     serve-static: ^1.15.0
     shelljs: ^0.8.5
-    toad-scheduler: ^2.2.0
+    toad-scheduler: ^1.6.1
     ts-node: ^10.9.1
     typescript: ^4.7.0
   languageName: unknown
@@ -1363,7 +1363,7 @@ __metadata:
     rimraf: ^3.0.2
     serve-static: ^1.15.0
     shelljs: ^0.8.5
-    toad-scheduler: ^2.2.0
+    toad-scheduler: ^1.6.1
     ts-node: ^10.9.1
     typescript: ^4.7.0
   languageName: unknown
@@ -1463,7 +1463,7 @@ __metadata:
     rimraf: ^3.0.2
     serve-static: ^1.15.0
     shelljs: ^0.8.5
-    toad-scheduler: ^2.2.0
+    toad-scheduler: ^1.6.1
     ts-mockito: ^2.0.0
     ts-node: ^10.9.1
     typechain: ^8.1.0
@@ -7407,10 +7407,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"toad-scheduler@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "toad-scheduler@npm:2.2.0"
-  checksum: ba5ccd788a6f2b40a69988f70ddcd1caad5594cfca81fe7aec1acf30d5eb1ac24481542f877d0bc972fa688f6cc448202db64a28384bd0fedd9a1116eba18dc0
+"toad-scheduler@npm:^1.6.1":
+  version: 1.6.1
+  resolution: "toad-scheduler@npm:1.6.1"
+  checksum: 0f3b16c851d67901360a76bf5c341c6b8f992de85a9b37d9fa498126134c4dc5c83d3b797070f8bcfc6e775e3d9f3ea1d32638de05521c9507701f085008a514
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Reverts mangrovedao/mangrove-ts#1216

Broke the arb bot tests