### PR TITLE
feat(Kandel): Allow price points to be generated outwards from midPrice with a hole

### DIFF
--- a/packages/mangrove.js/src/kandel/kandelDistribution.ts
+++ b/packages/mangrove.js/src/kandel/kandelDistribution.ts
@@ -134,14 +134,14 @@ class KandelDistribution {
     return chunks;
   }
 
-  /** Gets the prices for the distribution for the given subset of offers.
+  /** Gets the prices for the distribution, with undefined for prices not represented by offers in the distribution.
    * @returns The prices in the distribution.
    */
   public getPricesForDistribution() {
-    const prices: Big[] = Array(this.offers.length);
+    const prices: Big[] = Array(this.pricePoints).fill(undefined);
 
-    this.offers.forEach((o, i) => {
-      prices[i] = o.base.gt(0) ? o.quote.div(o.base) : undefined;
+    this.offers.forEach((o) => {
+      prices[o.index] = o.base.gt(0) ? o.quote.div(o.base) : undefined;
     });
     return prices;
   }
@@ -192,13 +192,13 @@ class KandelDistribution {
     }
   }
 
-  /** Determines the required provision for the offers in the distribution.
+  /** Determines the required provision for the listed offers in the distribution (disregarding the number of price points).
    * @param params The parameters used to calculate the provision.
    * @param params.market The market to get provisions for bids and asks from.
    * @param params.gasreq The gas required to execute a trade.
    * @param params.gasprice The gas price to calculate provision for.
    * @returns The provision required for the number of offers.
-   * @remarks This takes into account that each price point can become both an ask and a bid which both require provision.
+   * @remarks This takes into account that each of the offers represent a price point which can become both an ask and a bid which both require provision.
    */
   public async getRequiredProvision(params: {
     market: Market;

--- a/packages/mangrove.js/src/kandel/kandelDistributionGenerator.ts
+++ b/packages/mangrove.js/src/kandel/kandelDistributionGenerator.ts
@@ -45,13 +45,9 @@ class KandelDistributionGenerator {
       throw new Error("Both base and quote cannot be constant");
     }
 
-    const pricesAndRatio = this.priceCalculation.calculatePrices(
-      params.priceParams
-    );
-
     const { askGives, bidGives } =
       this.distributionHelper.calculateMinimumInitialGives(
-        pricesAndRatio.prices,
+        this.priceCalculation.calculatePrices(params.priceParams).prices,
         Big(params.minimumBasePerOffer),
         Big(params.minimumQuotePerOffer)
       );

--- a/packages/mangrove.js/src/kandel/kandelInstance.ts
+++ b/packages/mangrove.js/src/kandel/kandelInstance.ts
@@ -316,9 +316,10 @@ class KandelInstance {
     const prices = distribution.getPricesForDistribution();
     const pivots: number[] = Array(distribution.getOfferCount());
     for (let i = 0; i < pivots.length; i++) {
+      const offer = distribution.offers[i];
       pivots[i] = await this.market.getPivotId(
-        distribution.offers[i].offerType,
-        prices[i]
+        offer.offerType,
+        prices[offer.index]
       );
     }
     return pivots;

--- a/packages/mangrove.js/src/kandel/kandelSeeder.ts
+++ b/packages/mangrove.js/src/kandel/kandelSeeder.ts
@@ -171,7 +171,7 @@ class KandelSeeder {
     );
   }
 
-  /** Determines the required provision for the distribution prior to sowing.
+  /** Determines the required provision for the distribution prior to sowing based on the number of price points.
    * @param seed The parameters for sowing the Kandel instance.
    * @param distribution The distribution to determine the provision for.
    * @returns The provision required for the distribution.
@@ -183,10 +183,11 @@ class KandelSeeder {
   ) {
     const gasreq = await this.getDefaultGasreq(seed.onAave);
     const gasprice = await this.getBufferedGasprice(seed);
-    return distribution.getRequiredProvision({
+    return distribution.helper.getRequiredProvision({
       market: seed.market,
       gasprice,
       gasreq,
+      offerCount: distribution.pricePoints,
     });
   }
 

--- a/packages/mangrove.js/test/integration/kandel.integration.test.ts
+++ b/packages/mangrove.js/test/integration/kandel.integration.test.ts
@@ -469,13 +469,15 @@ describe("Kandel integration tests suite", function () {
           const firstBase = Big(1);
           const firstQuote = Big(1000);
           const pricePoints = 6;
+          const midPrice = Big(1200);
           const distribution = kandel.generator.calculateDistribution({
             priceParams: {
               minPrice: firstQuote.div(firstBase),
               ratio,
               pricePoints,
+              midPrice,
             },
-            midPrice: Big(1200),
+            midPrice,
             initialAskGives: firstBase,
           });
 
@@ -552,8 +554,8 @@ describe("Kandel integration tests suite", function () {
           );
           assert.equal(
             countOfferWrites,
-            6,
-            "there should be 1 offerWrite for each offer"
+            distribution.pricePoints - 1,
+            "there should be 1 offerWrite for each offer, and there is a hole"
           );
 
           const book = market.getBook();
@@ -585,7 +587,7 @@ describe("Kandel integration tests suite", function () {
             );
           }
           // assert bids
-          assert.equal(bids.length, 3, "3 bids should be populated");
+          assert.equal(bids.length, 2, "2 bids should be populated, 1 hole");
           for (let i = 0; i < bids.length; i++) {
             const offer = bids[bids.length - 1 - i];
             const d = distribution.offers[i];
@@ -1396,10 +1398,10 @@ describe("Kandel integration tests suite", function () {
         // Assert
         const oldPrices = existingDistribution
           .getPricesForDistribution()
-          .map((x) => x.round(4).toNumber());
+          .map((x) => x?.round(4).toNumber());
         const newPrices = result.distribution
           .getPricesForDistribution()
-          .map((x) => x.round(4).toNumber());
+          .map((x) => x?.round(4).toNumber());
         assert.deepStrictEqual(newPrices, oldPrices);
         assert.ok(result.totalBaseChange.neg().lt(offeredVolume.requiredBase));
         assert.ok(

--- a/packages/mangrove.js/test/unit/kandelDistribution.unit.test.ts
+++ b/packages/mangrove.js/test/unit/kandelDistribution.unit.test.ts
@@ -237,5 +237,22 @@ describe("KandelDistribution unit tests suite", () => {
         price = price.mul(ratio);
       });
     });
+
+    it("returns undefined for dead offers", () => {
+      // Arrange
+      const sut = new KandelDistribution(
+        Big(1),
+        3,
+        [{ offerType: "bids", base: Big(1), quote: Big(2000), index: 1 }],
+        4,
+        6
+      );
+
+      // Act/Assert
+      assert.deepStrictEqual(
+        sut.getPricesForDistribution().map((x) => x?.toNumber()),
+        [undefined, 2000, undefined]
+      );
+    });
   });
 });

--- a/packages/mangrove.js/test/unit/kandelDistributionGenerator.unit.test.ts
+++ b/packages/mangrove.js/test/unit/kandelDistributionGenerator.unit.test.ts
@@ -175,6 +175,34 @@ describe(`${KandelDistributionGenerator.prototype.constructor.name} unit tests s
         });
       });
 
+      it("can calculate distribution with constant base with midPrice", () => {
+        // Arrange/Act
+        const distribution = sut.calculateDistribution({
+          priceParams: { ...priceParams, midPrice: Big(4000) },
+          midPrice: Big(4000),
+          initialAskGives: Big(1),
+        });
+        const offeredVolume = distribution.getOfferedVolumeForDistribution();
+
+        // Assert
+        assert.equal(offeredVolume.requiredBase.toNumber(), 2);
+        assert.equal(offeredVolume.requiredQuote.toNumber(), 3000);
+        assert.equal(distribution.pricePoints, pricePoints);
+        assert.equal(
+          distribution.getOfferCount(),
+          pricePoints - 1,
+          "A hole should be left for the midPrice"
+        );
+        distribution.offers.forEach((d) => {
+          assert.equal(d.base.toNumber(), 1, `wrong base at ${d.index}`);
+          assert.equal(
+            d.quote.toNumber(),
+            minPrice.mul(ratio.pow(d.index)).toNumber(),
+            `wrong quote at ${d.index}`
+          );
+        });
+      });
+
       it("can calculate distribution with constant quote", () => {
         // Arrange/Act
         const distribution = sut.calculateDistribution({

--- a/packages/mangrove.js/test/unit/kandelDistributionHelper.unit.test.ts
+++ b/packages/mangrove.js/test/unit/kandelDistributionHelper.unit.test.ts
@@ -28,13 +28,13 @@ describe("KandelDistributionHelper unit tests suite", () => {
       it("can calculate distribution with fixed base volume and fixed quote volume which follows geometric price distribution", () => {
         // Arrange
         const sut = new KandelDistributionHelper(4, 6);
-        const prices = [1000, 2000, 4000, 8000, 16000, 32000];
+        const prices = [1000, 2000, 4000, undefined, 8000, 16000, 32000];
         const firstAskIndex = 3;
 
         // Act
         const distribution = sut.calculateDistributionConstantGives(
           Big(2),
-          prices.map((x) => Big(x)),
+          prices.map((x) => (x ? Big(x) : undefined)),
           Big(1),
           Big(1000),
           firstAskIndex
@@ -43,7 +43,7 @@ describe("KandelDistributionHelper unit tests suite", () => {
         // Assert
         const calculatedPrices = distribution
           .getPricesForDistribution()
-          .map((x) => x.toNumber());
+          .map((x) => x?.toNumber());
         assert.deepStrictEqual(
           prices,
           calculatedPrices,
@@ -65,13 +65,13 @@ describe("KandelDistributionHelper unit tests suite", () => {
         it(`can calculate distribution with only ${offerType}`, () => {
           // Arrange
           const sut = new KandelDistributionHelper(4, 6);
-          const prices = [1000, 2000];
+          const prices = [1000, 2000, undefined];
           const firstAskIndex = offerType == "bids" ? 10 : 0;
 
           // Act
           const distribution = sut.calculateDistributionConstantGives(
             Big(2),
-            prices.map((x) => Big(x)),
+            prices.map((x) => (x ? Big(x) : undefined)),
             Big(1),
             Big(1000),
             firstAskIndex
@@ -85,7 +85,7 @@ describe("KandelDistributionHelper unit tests suite", () => {
           );
           const calculatedPrices = distribution
             .getPricesForDistribution()
-            .map((x) => x.toNumber());
+            .map((x) => x?.toNumber());
           assert.deepStrictEqual(
             prices,
             calculatedPrices,
@@ -201,6 +201,7 @@ describe("KandelDistributionHelper unit tests suite", () => {
           minPrice: firstQuote.div(firstBase),
           ratio,
           pricePoints,
+          midPrice: firstQuote.div(firstBase).mul(ratio),
         });
 
         // Act
@@ -260,7 +261,7 @@ describe("KandelDistributionHelper unit tests suite", () => {
 
         // Act
         const { askGives, bidGives } = sut.calculateMinimumInitialGives(
-          [Big(1000)],
+          [undefined, undefined, Big(1000)],
           Big(0.1),
           Big(100)
         );
@@ -438,10 +439,10 @@ describe("KandelDistributionHelper unit tests suite", () => {
       let sut: KandelDistributionHelper;
       beforeEach(() => {
         sut = new KandelDistributionHelper(4, 6);
-        prices = [1000, 2000, 4000, 8000, 16000, 32000];
+        prices = [1000, 2000, 4000, undefined, 8000, 16000, 32000];
         distribution = sut.calculateDistributionConstantGives(
           Big(2),
-          prices.map((x) => Big(x)),
+          prices.map((x) => (x ? Big(x) : undefined)),
           Big(10),
           Big(10000),
           3
@@ -465,7 +466,7 @@ describe("KandelDistributionHelper unit tests suite", () => {
         // Assert
         const newPrices = result.distribution.getPricesForDistribution();
         assert.deepStrictEqual(
-          newPrices.map((x) => x.toNumber()),
+          newPrices.map((x) => x?.toNumber()),
           prices,
           "prices should be left unchanged"
         );

--- a/packages/mangrove.js/test/unit/kandelPriceCalculation.unit.test.ts
+++ b/packages/mangrove.js/test/unit/kandelPriceCalculation.unit.test.ts
@@ -6,61 +6,72 @@ import UnitCalculations from "../../src/util/unitCalculations";
 
 describe("KandelPriceCalculation unit tests suite", () => {
   describe(KandelPriceCalculation.prototype.calculatePrices.name, () => {
-    it("calculates sames prices for all combinations ", () => {
-      // Arrange
-      const minPrice = Big(1001);
-      const maxPrice = Big(1588.461197266944);
-      const ratio = Big(1.08);
-      const pricePoints = 7;
-      const sut = new KandelPriceCalculation(5);
+    [undefined, Big(1260.971712)].forEach((midPrice) => {
+      it(`calculates sames prices for all combinations of minPrice, maxPrice, and pricePoints with midPrice=${midPrice}`, () => {
+        // Arrange
+        const minPrice = Big(1001);
+        const maxPrice = Big(1588.461197266944);
+        const ratio = Big(1.08);
+        const pricePoints = 7;
+        const sut = new KandelPriceCalculation(5);
 
-      // Act
-      const pricesAndRatio1 = sut.calculatePrices({
-        minPrice,
-        maxPrice,
-        ratio,
-      });
-      const pricesAndRatio2 = sut.calculatePrices({
-        minPrice,
-        maxPrice,
-        pricePoints,
-      });
-      const pricesAndRatio3 = sut.calculatePrices({
-        minPrice,
-        ratio,
-        pricePoints,
-      });
-      const pricesAndRatio4 = sut.calculatePrices({
-        maxPrice,
-        ratio,
-        pricePoints,
-      });
+        // Act
+        const pricesAndRatio1 = sut.calculatePrices({
+          minPrice,
+          maxPrice,
+          ratio,
+          midPrice,
+        });
+        const pricesAndRatio2 = sut.calculatePrices({
+          minPrice,
+          maxPrice,
+          pricePoints,
+          midPrice,
+        });
+        const pricesAndRatio3 = sut.calculatePrices({
+          minPrice,
+          ratio,
+          pricePoints,
+          midPrice,
+        });
+        const pricesAndRatio4 = sut.calculatePrices({
+          maxPrice,
+          ratio,
+          pricePoints,
+          midPrice,
+        });
 
-      // Assert
-      const expectedPrices = [
-        1001, 1081.08, 1167.5664, 1260.971712, 1361.84944896, 1470.7974048768,
-        1588.461197266944,
-      ];
-      assert.deepStrictEqual(
-        pricesAndRatio1.prices.map((x) => x.toNumber()),
-        expectedPrices
-      );
-      assert.deepStrictEqual(
-        pricesAndRatio2.prices.map((x) => x.toNumber()),
-        expectedPrices
-      );
-      assert.deepStrictEqual(
-        pricesAndRatio3.prices.map((x) => x.toNumber()),
-        expectedPrices
-      );
-      assert.deepStrictEqual(
-        pricesAndRatio4.prices.map((x) => x.toNumber()),
-        expectedPrices
-      );
-      assert.equal(pricesAndRatio1.ratio.toNumber(), ratio.toNumber());
-      assert.equal(pricesAndRatio2.ratio.toNumber(), ratio.toNumber());
-      assert.equal(pricesAndRatio3.ratio.toNumber(), ratio.toNumber());
-      assert.equal(pricesAndRatio4.ratio.toNumber(), ratio.toNumber());
+        // Assert
+        const expectedPrices = [
+          1001,
+          1081.08,
+          1167.5664,
+          midPrice ? undefined : 1260.971712,
+          1361.84944896,
+          1470.7974048768,
+          1588.461197266944,
+        ];
+        assert.deepStrictEqual(
+          pricesAndRatio1.prices.map((x) => x?.toNumber()),
+          expectedPrices
+        );
+        assert.deepStrictEqual(
+          pricesAndRatio2.prices.map((x) => x?.toNumber()),
+          expectedPrices
+        );
+        assert.deepStrictEqual(
+          pricesAndRatio3.prices.map((x) => x?.toNumber()),
+          expectedPrices
+        );
+        assert.deepStrictEqual(
+          pricesAndRatio4.prices.map((x) => x?.toNumber()),
+          expectedPrices
+        );
+        assert.equal(pricesAndRatio1.ratio.toNumber(), ratio.toNumber());
+        assert.equal(pricesAndRatio2.ratio.toNumber(), ratio.toNumber());
+        assert.equal(pricesAndRatio3.ratio.toNumber(), ratio.toNumber());
+        assert.equal(pricesAndRatio4.ratio.toNumber(), ratio.toNumber());
+      });
     });
 
     it("can get 2 pricePoints from minPrice and maxPrice", () => {
@@ -110,7 +121,7 @@ describe("KandelPriceCalculation unit tests suite", () => {
   describe(
     KandelPriceCalculation.prototype.calculatePricesFromMinMaxRatio.name,
     () => {
-      it("calculates expected price points", () => {
+      it("calculates expected price points without midPrice", () => {
         // Arrange/act
         const prices = new KandelPriceCalculation(
           5
@@ -120,6 +131,25 @@ describe("KandelPriceCalculation unit tests suite", () => {
         assert.deepStrictEqual(
           prices.map((x) => x.toNumber()),
           [1000, 2000, 4000, 8000, 16000, 32000]
+        );
+      });
+
+      it("calculates expected price points with midPrice", () => {
+        // Arrange/act
+        const prices = new KandelPriceCalculation(
+          5
+        ).calculatePricesFromMinMaxRatio(
+          Big(1000),
+          Big(2),
+          Big(32000),
+          undefined,
+          Big(4000)
+        );
+
+        // Assert
+        assert.deepStrictEqual(
+          prices.map((x) => x?.toNumber()),
+          [1000, 2000, undefined, 8000, 16000, 32000]
         );
       });
 
@@ -167,10 +197,12 @@ describe("KandelPriceCalculation unit tests suite", () => {
       { midPrice: 999, expected: 0 },
       { midPrice: 1000, expected: 1 },
       { midPrice: 1001, expected: 1 },
-      { midPrice: 3001, expected: 3 },
+      { midPrice: 3001, expected: 4 },
     ].forEach(({ midPrice, expected }) => {
       it(`can get firstAskIndex=${expected} in rage`, () => {
-        const prices = [1000, 2000, 3000].map((x) => Big(x));
+        const prices = [1000, 2000, undefined, 3000].map((x) =>
+          x ? Big(x) : undefined
+        );
         assert.equal(
           new KandelPriceCalculation(5).calculateFirstAskIndex(
             Big(midPrice),


### PR DESCRIPTION
Previously prices where generated from minPrice and upwards by multiplying by ratio until we hit maxPrice.
Now, if a midPrice is supplied, we generated outwards from that until we hit minPrice and maxPrice, with a hole at the midPrice.

Note: this required additional changes since multiple places did not support a hole in the list of prices, and for instance the initial provision for a distribution should be for the entire list, and not disregard the hole.