### PR TITLE
fixing NotEnoughGasForMaker reverts

### DIFF
--- a/packages/mangrove.js/CHANGELOG.md
+++ b/packages/mangrove.js/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Next version
 
 - Use array to handle market subscription
+- [bug fix] gas estimates for market orders is boosted to avoid `NotEnoughGasForMaker` type of tx failures.
+- max gas limit for market orders is set to 10,000,000
 
 # 1.2.6-2
 

--- a/packages/mangrove.js/src/market.ts
+++ b/packages/mangrove.js/src/market.ts
@@ -8,7 +8,7 @@ import Trade from "./util/trade";
 
 let canConstructMarket = false;
 
-const MAX_MARKET_ORDER_GAS = 6500000;
+const MAX_MARKET_ORDER_GAS = 10000000;
 
 /* Note on big.js:
 ethers.js's BigNumber (actually BN.js) only handles integers
@@ -640,9 +640,14 @@ class Market {
 
     const maxGasreqOffer = (await semibook.getMaxGasReq()) ?? 0;
     const maxMarketOrderGas: BigNumber = BigNumber.from(MAX_MARKET_ORDER_GAS);
+    // boosting estimates of 10% to be on the safe side
     const estimation = density.isZero()
       ? maxMarketOrderGas
-      : offer_gasbase.add(volume.div(density)).add(maxGasreqOffer);
+      : offer_gasbase
+          .add(volume.div(density))
+          .add(maxGasreqOffer)
+          .mul(11)
+          .div(10);
 
     if (estimation.lt(maxMarketOrderGas)) return estimation;
 


### PR DESCRIPTION
This PR increases gasEstimates of market.ts by 10%. This is to allow a buffer of underestimation is gasbase which is not precise.