### PR TITLE
feat(Kandel): Chunk populate and retract around midprice

### DIFF
--- a/packages/mangrove.js/test/integration/kandel.integration.test.ts
+++ b/packages/mangrove.js/test/integration/kandel.integration.test.ts
@@ -1506,6 +1506,7 @@ describe("Kandel integration tests suite", function () {
             await waitForTransactions(
               await kandel.retractOffers({
                 maxOffersInChunk: inChunks ? 2 : 80,
+                firstAskIndex: 3,
               })
             );
 
@@ -1523,6 +1524,7 @@ describe("Kandel integration tests suite", function () {
                 startIndex: 4,
                 endIndex: 6,
                 maxOffersInChunk: inChunks ? 1 : 80,
+                firstAskIndex: 3,
               })
             );
 

--- a/packages/mangrove.js/test/unit/kandelDistributionHelper.unit.test.ts
+++ b/packages/mangrove.js/test/unit/kandelDistributionHelper.unit.test.ts
@@ -539,6 +539,60 @@ describe("KandelDistributionHelper unit tests suite", () => {
     });
   });
 
+  describe(
+    KandelDistributionHelper.prototype.chunkIndicesAroundMiddle.name,
+    () => {
+      let sut: KandelDistributionHelper;
+      beforeEach(() => {
+        sut = new KandelDistributionHelper(0, 0);
+      });
+
+      [undefined, 2].forEach((middle) => {
+        it(`can chunk an uneven set with middle=${middle}`, () => {
+          // Arrange/act
+          const chunks = sut.chunkIndicesAroundMiddle(1, 4, 2, middle);
+
+          // Assert
+          assert.equal(chunks.length, 2);
+          assert.deepStrictEqual(chunks[0], { from: 1, to: 3 });
+          assert.deepStrictEqual(chunks[1], { from: 3, to: 4 });
+        });
+      });
+
+      it("can chunk an even set", () => {
+        // Arrange/act
+        const chunks = sut.chunkIndicesAroundMiddle(1, 9, 2, 6);
+
+        // Assert
+        assert.equal(chunks.length, 4);
+        assert.deepStrictEqual(chunks[0], { from: 5, to: 7 });
+        assert.deepStrictEqual(chunks[1], { from: 3, to: 5 });
+        assert.deepStrictEqual(chunks[2], { from: 7, to: 9 });
+        assert.deepStrictEqual(chunks[3], { from: 1, to: 3 });
+      });
+
+      it(`works with middle=0`, () => {
+        // Arrange/act
+        const chunks = sut.chunkIndicesAroundMiddle(1, 5, 2, 0);
+
+        // Assert
+        assert.equal(chunks.length, 2);
+        assert.deepStrictEqual(chunks[0], { from: 1, to: 3 });
+        assert.deepStrictEqual(chunks[1], { from: 3, to: 5 });
+      });
+
+      it(`works with middle=4`, () => {
+        // Arrange/act
+        const chunks = sut.chunkIndicesAroundMiddle(1, 5, 2, 4);
+
+        // Assert
+        assert.equal(chunks.length, 2);
+        assert.deepStrictEqual(chunks[0], { from: 3, to: 5 });
+        assert.deepStrictEqual(chunks[1], { from: 1, to: 3 });
+      });
+    }
+  );
+
   describe(KandelDistributionHelper.prototype.sortByIndex.name, () => {
     it("sorts", () => {
       // Arrange


### PR DESCRIPTION
When multiple transactions are needed due to populating many offers, then we first populate those around the mid price (which is indicated via the first ask), and then we radiate outwards.

For retract, we do the reverse, however, retract only supports index ranges, we retract ranges furthest from the mid price, and finally the range centered around the mid price. This means that we can end up using one more tx for retract compared to populate, since the two ranges at the ends cannot be combined.