### PR TITLE
fix(gas): Increase gas estimation, to account for 64/63 reserved in posthook

### DIFF
--- a/packages/mangrove.js/src/market.ts
+++ b/packages/mangrove.js/src/market.ts
@@ -646,6 +646,7 @@ class Market {
       : offer_gasbase
           .add(volume.div(density))
           .add(maxGasreqOffer)
+          .add(BigNumber.from(maxGasreqOffer).mul(64).div(63))
           .mul(11)
           .div(10);
 

--- a/packages/mangrove.js/test/integration/market.integration.test.ts
+++ b/packages/mangrove.js/test/integration/market.integration.test.ts
@@ -1492,7 +1492,13 @@ describe("Market integration tests suite", () => {
     const asksEstimate = await market.estimateGas("buy", BigNumber.from(1));
     expect(asksEstimate.toNumber()).to.be.equal(
       emptyBookAsksEstimate
-        .add(BigNumber.from(askGasReq).mul(11).div(10))
+        .add(
+          BigNumber.from(askGasReq)
+            .add(BigNumber.from(askGasReq).mul(64).div(63))
+            .mul(11)
+            .div(10)
+        )
+        .add(1 /* due to precision */)
         .toNumber()
     );
   });


### PR DESCRIPTION
We check whether 63/64*gasleft() is > gasreqforposthook  in MgvOfferTaking.makerPosthook, so I think we should use the following instead of just maxGasreqOffer in estimateGas
I think that density and/offer_gasbase are underestimated, possibly due to using TestTokens. So even the above change is not enough. So I propose we simply add the new maxGasreqOffer on top of the existing, that is done in this change.