### PR TITLE
feat(gas): Make gas estimation explicit in orders to allow usage of ethers estimate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Next version
 
 - Change mangrove-ts to a single package repo for mangrove.js.
+- Make gas estimation explicit to allow usage of ethers estimation.
 
 # 1.2.10
 

--- a/src/liquidityProvider.ts
+++ b/src/liquidityProvider.ts
@@ -72,7 +72,7 @@ class LiquidityProvider {
           )
         : undefined;
       this.market = p.market;
-      this.eoa = p.eoa;
+      this.eoa = p.eoa ? ethers.utils.getAddress(p.eoa) : undefined;
       this.gasreq = p.gasreq;
     } else {
       throw Error(

--- a/src/market.ts
+++ b/src/market.ts
@@ -590,6 +590,16 @@ class Market {
     return this.trade.order("sell", params, this, overrides);
   }
 
+  /** Estimate amount of gas for buy. Can be passed as overrides.gasLimit or params.gasLowerBound of @see buy with same params. */
+  gasEstimateBuy(params: Market.TradeParams): Promise<BigNumber> {
+    return this.trade.estimateGas("buy", params, this);
+  }
+
+  /** Estimate amount of gas for sell. Can be passed as overrides.gasLimit or params.gasLowerBound of @see sell with same params. */
+  gasEstimateSell(params: Market.TradeParams): Promise<BigNumber> {
+    return this.trade.estimateGas("sell", params, this);
+  }
+
   /**
    * Snipe specific offers.
    * Params are:

--- a/src/market.ts
+++ b/src/market.ts
@@ -74,6 +74,7 @@ namespace Market {
     slippage?: number;
     fillOrKill?: boolean;
     expiryDate?: number;
+    gasLowerBound?: ethers.ethers.BigNumberish;
   } & ({ restingOrder?: RestingOrderParams } | { offerId?: number }) &
     (
       | { volume: Bigish; price: Bigish }

--- a/src/offerLogic.ts
+++ b/src/offerLogic.ts
@@ -18,10 +18,10 @@ class OfferLogic {
 
   constructor(mgv: Mangrove, logic: string, signer?: SignerOrProvider) {
     this.mgv = mgv;
-    this.address = logic;
+    this.address = ethers.utils.getAddress(logic);
     this.signerOrProvider = signer ?? this.mgv.signer;
     this.contract = typechain.IOfferLogic__factory.connect(
-      logic,
+      this.address,
       this.signerOrProvider
     );
   }

--- a/src/util/trade.ts
+++ b/src/util/trade.ts
@@ -7,6 +7,8 @@ import logger from "./logger";
 import TradeEventManagement from "./tradeEventManagement";
 import UnitCalculations from "./unitCalculations";
 
+const MANGROVE_ORDER_GAS_OVERHEAD = 200000;
+
 type SnipeUnitParams = {
   ba: Market.BA;
   targets: {
@@ -310,7 +312,9 @@ class Trade {
     switch (orderType) {
       case "restingOrder":
         // add an overhead of the MangroveOrder contract on top of the estimated market order.
-        return (await market.estimateGas(bs, wants)).add(200000);
+        return (await market.estimateGas(bs, wants)).add(
+          MANGROVE_ORDER_GAS_OVERHEAD
+        );
       case "snipe":
         return undefined;
       case "marketOrder":
@@ -330,7 +334,7 @@ class Trade {
       case "restingOrder":
         // add an overhead of the MangroveOrder contract on top of the estimated market order.
         return (await market.simulateGas(ba, gives, wants, fillWants)).add(
-          200000
+          MANGROVE_ORDER_GAS_OVERHEAD
         );
       case "snipe":
         return undefined;

--- a/src/util/trade.ts
+++ b/src/util/trade.ts
@@ -643,16 +643,15 @@ class Trade {
       },
     });
 
-    // user defined gasLimit overrides estimates
+    // user defined gasLimit is a total max for gasreq of each offer; otherwise, each offer is allowed to use its specified gasreq,
+    // this is accomplished by supplying a number larger than 2^24-1 for the offer (in this case MaxUint256).
     const _targets = unitParams.targets.map<
       Market.RawSnipeParams["targets"][number]
     >((t) => [
       t.offerId,
       t.takerWants,
       t.takerGives,
-      t.gasLimit ??
-        overrides.gasLimit ??
-        market.estimateGas(this.baToBs(unitParams.ba), t.takerWants),
+      t.gasLimit ?? overrides.gasLimit ?? ethers.constants.MaxUint256,
     ]);
 
     return {


### PR DESCRIPTION
* fix(offerLogic): Addresses should be checksum addresses when used in comparisons
* feat(trade): Extract getRawParams
* feat(gas): Make gas estimation explicit in orders to allow usage of ethers estimate
* fix(snipe): Do not use gas estimate when sniping
* feat(market): Expose gas estimation functions
